### PR TITLE
Remove init array skip

### DIFF
--- a/cpu_arm64.S
+++ b/cpu_arm64.S
@@ -285,7 +285,6 @@ _start:
 call_constructors:
     mov     x19, lr                     // Save Link Register (x30)
     ldr     x0, =__init_array_start     // Start of .init_array
-    add     x0, x0, #8                 // Skip first libgcc constructor
     ldr     x1, =__init_array_end       // End of .init_array
 .L_init_loop:
     cmp     x0, x1                      // Compare current pointer with end


### PR DESCRIPTION
## Summary
- let call_constructors iterate from __init_array_start to __init_array_end

## Testing
- `make clean`
- `timeout 60 make debug` *(fails: Unhandled exception in call_constructors)*

------
https://chatgpt.com/codex/tasks/task_e_68405285a44883258d1871ab5e80ba5e