### PR TITLE
Add optional early tracing init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # Bare-metal build with freestanding utilities
 
 TARGET ?= arm64
+ENABLE_TRACE ?= 1
 
 ifeq ($(TARGET),arm64)
     CC = aarch64-linux-gnu-g++
@@ -13,6 +14,7 @@ ifeq ($(TARGET),arm64)
     CFLAGS  = -g -O0
     CFLAGS += -Wall -Wextra -fno-exceptions -fno-rtti -mcpu=cortex-a53 -march=armv8-a+simd -std=c++20 -I. -fno-PIE -Woverloaded-virtual -ffreestanding
     CFLAGS += -ffunction-sections -fdata-sections -fno-stack-protector -fno-omit-frame-pointer -Wshadow -Wcast-align -Wdouble-promotion
+    CFLAGS += -DTRACE_DEFAULT_ENABLED=$(ENABLE_TRACE)
 	
     ASFLAGS = -mcpu=cortex-a53 -march=armv8-a -g3
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ miniOS/
    ```bash
    make
    ```
-   Produces `miniOS.bin`.
+   Produces `miniOS.bin`. Set `ENABLE_TRACE=0` to disable tracing at compile time:
+   ```bash
+   make ENABLE_TRACE=0
+   ```
 3. **Run in QEMU**:
    ```bash
    make run

--- a/core.cpp
+++ b/core.cpp
@@ -391,6 +391,13 @@ void get_kernel_stats(hal::UARTDriverOps* uart_ops) {
 }
 
 extern "C" void kernel_main() {
+    trace::g_trace_manager.init();
+#if TRACE_DEFAULT_ENABLED
+    trace::g_trace_manager.set_enabled(true);
+#else
+    trace::g_trace_manager.set_enabled(false);
+#endif
+
     early_uart_puts("[DEBUG] Entering kernel_main\n");
     g_platform = hal::get_platform();
     early_uart_puts("[DEBUG] Got platform\n");
@@ -419,8 +426,6 @@ extern "C" void kernel_main() {
                                               alignof(hal::timer::SoftwareTimer))) {
         g_platform->panic("Failed to init software timer pool", __FILE__, __LINE__); return;
     }
-    trace::g_trace_manager.init();
-    trace::g_trace_manager.set_enabled(true);
 
     for (uint32_t i = 0; i < g_platform->get_num_cores(); ++i) {
         char idle_name[core::MAX_NAME_LENGTH];

--- a/trace.hpp
+++ b/trace.hpp
@@ -20,6 +20,10 @@
 #ifndef TRACE_HPP
 #define TRACE_HPP
 
+#ifndef TRACE_DEFAULT_ENABLED
+#define TRACE_DEFAULT_ENABLED 1
+#endif
+
 #include "core.hpp"
 #include "hal.hpp"
 #include <span>


### PR DESCRIPTION
## Summary
- allow tracing to be toggled at compile time
- initialize trace manager before starting threads
- document `ENABLE_TRACE` build option

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685b0d7ba1d0832581f996bbaf3cc163