### PR TITLE
Add IPv4 string helpers

### DIFF
--- a/cli.cpp
+++ b/cli.cpp
@@ -184,7 +184,12 @@ int cli_net_ping_command(const char* args, kernel::hal::UARTDriverOps* uart_ops)
         uart_ops->puts("Usage: ping <ip>\n");
         return -1;
     }
-    kernel::g_net_manager.ping(target_ip, 3, uart_ops);
+    net::IPv4Addr ip{};
+    if (!net::from_string(target_ip, ip)) {
+        uart_ops->puts("Invalid IP address\n");
+        return -1;
+    }
+    kernel::g_net_manager.ping(ip, 3, uart_ops);
     return 0;
 }
 
@@ -379,7 +384,7 @@ int cli_net_send_udp_command(const char* args, kernel::hal::UARTDriverOps* uart_
     }
 
     net::IPv4Addr addr;
-    if (!addr.from_string(ip)) {
+    if (!net::from_string(ip, addr)) {
         uart_ops->puts("Invalid IP address\n");
         return -1;
     }

--- a/demo_cli_dsp.cpp
+++ b/demo_cli_dsp.cpp
@@ -167,8 +167,8 @@ private:
             uart_ops->puts("Usage: confignet <ip> <port> <channels>\n");
             return 1;
         }
-        uint32_t ip_addr;
-        if (!kernel::util::ipv4_to_uint32(ip_str, ip_addr)) {
+        net::IPv4Addr ip_addr;
+        if (!net::from_string(ip_str, ip_addr)) {
             uart_ops->puts("Invalid IP address\n");
             return 1;
         }

--- a/dsp.cpp
+++ b/dsp.cpp
@@ -681,8 +681,8 @@ void NetworkAudioSinkSource::configure(const char* args, kernel::hal::UARTDriver
             return; 
         }
 
-        if (!kernel::util::ipv4_to_uint32(ip_str_val, remote_target_ip_.addr)) {
-            if (uart_ops) uart_ops->puts("Invalid IP address string.\n"); 
+        if (!net::from_string(ip_str_val, remote_target_ip_)) {
+            if (uart_ops) uart_ops->puts("Invalid IP address string.\n");
             return;
         }
         if (port_val <= 0 || port_val > 65535) { 

--- a/net.hpp
+++ b/net.hpp
@@ -25,6 +25,9 @@ struct IPv4Addr {
     uint32_t addr;
 };
 
+bool from_string(std::string_view ip_str, IPv4Addr& out) noexcept;
+void to_string(char* buf, size_t bufsz, IPv4Addr addr) noexcept;
+
 struct Packet {
     IPv4Addr dst_ip;
     uint16_t dst_port;


### PR DESCRIPTION
## Summary
- add helpers to parse/format IPv4 addresses
- use helpers in CLI and DSP modules
- print socket addresses using helper

## Testing
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_685b0d7bc2248325b8c6e3764937d0a5