### PR TITLE
Define MAX_INTERRUPTS constant

### DIFF
--- a/gpio.cpp
+++ b/gpio.cpp
@@ -30,8 +30,11 @@ GPIOManager::GPIOManager() : gpio_ops_(nullptr), initialized_(false) {
     for (auto& bank : banks_) {
         for (auto& pin : bank.pin_output_enabled) pin = false;
         for (auto& pin : bank.pin_state) pin = false;
-        for (auto& intr : bank.interrupt_enabled) intr = false;
-        for (auto& edge : bank.interrupt_rising_edge) edge = false;
+        for (size_t i = 0; i < MAX_INTERRUPTS; ++i) {
+            bank.interrupt_enabled[i] = false;
+            bank.interrupt_rising_edge[i] = false;
+            bank.interrupt_pins[i] = 0;
+        }
         bank.interrupt_count = 0;
     }
 }

--- a/gpio.hpp
+++ b/gpio.hpp
@@ -18,6 +18,8 @@
 
 namespace gpio {
 
+constexpr size_t MAX_INTERRUPTS = 64;
+
 class GPIOManager {
 public:
     GPIOManager() = default;


### PR DESCRIPTION
## Summary
- add MAX_INTERRUPTS constant to gpio subsystem
- initialise interrupt arrays using MAX_INTERRUPTS

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685b0d6973848325b093c1e1e0f6cc03