### PR TITLE
Implement audio system structures and stub implementation

### DIFF
--- a/audio.hpp
+++ b/audio.hpp
@@ -2,29 +2,69 @@
 /**
  * @file audio.hpp
  * @brief Audio subsystem interfaces for miniOS v1.7.
- * @details
- * Defines interfaces for audio buffer management and processing, supporting low-latency
- * audio for network audio products. Updated in v1.7 for modularity and C++20 compatibility.
- *
- * @version 1.7
- * @see audio.cpp, core.hpp, hal.hpp
  */
 
 #ifndef AUDIO_HPP
 #define AUDIO_HPP
 
+#include "core.hpp"
 #include "hal.hpp"
-#include <cstdint>
+#include <memory>
+
+namespace dsp { class DSPGraph; }
 
 namespace kernel {
 namespace audio {
 
 struct AudioBuffer {
-    void* data_raw_i2s = nullptr; // Raw I2S data
-    float* data_dsp_canonical = nullptr; // DSP-processed data
+    void*  data_raw_i2s = nullptr;
+    float* data_dsp_canonical = nullptr;
     size_t size_bytes_raw_buffer = 0;
     size_t samples_per_channel = 0;
     uint8_t channels = 2;
+};
+
+struct AudioConfig {
+    uint32_t sample_rate_hz;
+    size_t   samples_per_block;
+    uint8_t  num_channels;
+    uint8_t  num_i2s_dma_buffers;
+    size_t   num_audio_pool_buffers; // buffers from global pool
+    uint32_t i2s_rx_instance_id;
+    uint32_t i2s_tx_instance_id;
+};
+
+class AudioSystem {
+public:
+    AudioSystem() = default;
+    ~AudioSystem() = default;
+
+    bool init(const AudioConfig& config);
+    bool start();
+    void stop();
+
+    dsp::DSPGraph&       get_dsp_graph();
+    const dsp::DSPGraph& get_dsp_graph() const;
+
+    AudioSystem(const AudioSystem&) = delete;
+    AudioSystem& operator=(const AudioSystem&) = delete;
+
+private:
+    static void i2s_rx_callback(uint32_t instance_id, AudioBuffer* buffer,
+                                kernel::hal::i2s::Mode mode, void* user_data);
+    static void i2s_tx_callback(uint32_t instance_id, AudioBuffer* buffer,
+                                kernel::hal::i2s::Mode mode, void* user_data);
+    static void dsp_thread(void* arg);
+
+    AudioConfig config_{};
+    bool is_running_ = false;
+    kernel::core::TCB* dsp_thread_tcb_ = nullptr;
+    std::unique_ptr<dsp::DSPGraph> dsp_graph_;
+    std::unique_ptr<kernel::core::FixedMemoryPool> audio_buffer_pool_;
+    std::unique_ptr<kernel::core::SPSCQueue<AudioBuffer, 16>> i2s_rx_to_dsp_queue_;
+    std::unique_ptr<kernel::core::SPSCQueue<AudioBuffer, 16>> dsp_to_app_rx_queue_;
+    std::unique_ptr<kernel::core::SPSCQueue<AudioBuffer, 16>> app_tx_to_dsp_queue_;
+    std::unique_ptr<kernel::core::SPSCQueue<AudioBuffer, 16>> dsp_to_i2s_tx_queue_;
 };
 
 } // namespace audio


### PR DESCRIPTION
## Summary
- add full `AudioSystem` API to `audio.hpp`
- implement minimal audio queueing and DSP thread logic in `audio.cpp`
- include `num_audio_pool_buffers` in `AudioConfig`

## Testing
- `make kernel`

------
https://chatgpt.com/codex/tasks/task_e_685b0d6e418883259920ab4a6d545415