### PR TITLE
Phase B mill-turn sync + lights-out automation

### DIFF
--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -121,5 +121,22 @@ jobs:
           else
               TARGET_BRANCH="${GITHUB_REF#refs/heads/}"
           fi
+          # Race-tolerant push. If the target branch advanced while CI
+          # was running (typical when a developer pushes more commits
+          # to the PR head while the screenshot job is in flight), the
+          # plain push fails non-fast-forward and the whole job is
+          # marked failed even though the captures are fine. Fetch and
+          # bail-out cleanly when behind so the operator can re-run the
+          # workflow against the fresh tip.
+          git fetch origin "${TARGET_BRANCH}"
+          REMOTE_TIP=$(git rev-parse "origin/${TARGET_BRANCH}")
+          PARENT=$(git rev-parse HEAD~1)
+          if [ "${REMOTE_TIP}" != "${PARENT}" ]; then
+              echo "Target branch ${TARGET_BRANCH} advanced since CI checkout"
+              echo "  expected parent: ${PARENT}"
+              echo "  remote tip:      ${REMOTE_TIP}"
+              echo "Skipping screenshot auto-commit; artifacts uploaded for manual review."
+              exit 0
+          fi
           echo "Pushing screenshot commit to ${TARGET_BRANCH}"
           git push origin "HEAD:${TARGET_BRANCH}"

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,9 @@ $(OBJDIR)/%.o: automation/%.cpp | $(OBJDIR)
 $(OBJDIR)/%.o: ui/%.cpp | $(OBJDIR)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
+$(OBJDIR)/%.o: cnc/%.cpp | $(OBJDIR)
+	$(CC) $(CFLAGS) -c -o $@ $<
+
 $(OBJDIR)/virtio_blk.o: hal/shared/virtio_blk.cpp | $(OBJDIR)
 	$(CC) $(CFLAGS) -c -o $@ $<
 $(OBJDIR)/fat32.o: fs/fat32.cpp | $(OBJDIR)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CORE_CPP = core.cpp hal.cpp util.cpp trace.cpp klog.cpp cli.cpp kernel_globals.c
 ui/fb.cpp ui/splash.cpp ui/display.cpp ui/operator_api.cpp \
              ui/ui_builder_tsv.cpp machine/machine_registry.cpp machine/machine_topology.cpp machine/runtime_placement.cpp machine/motion_wiring.cpp automation/macro_runtime.cpp automation/ladder_runtime.cpp automation/probe_runtime.cpp automation/signals.cpp machine/toolpods.cpp machine/pallet.cpp hmi/hmi_service.cpp \
               cnc/offsets.cpp cnc/programs.cpp cnc/interpreter.cpp cnc/mdi.cpp \
-              cnc/setup.cpp \
+              cnc/setup.cpp cnc/jobs.cpp \
              render/gles1.cpp render/machine_model.cpp render/kinematic_model.cpp \
              render/obj_importer.cpp render/obj_registry.cpp render/stl_importer.cpp \
              render/benchmark.cpp fs/vfs.cpp fs/fat32.cpp fs/fs_fat32.cpp
@@ -174,7 +174,7 @@ CORE_CPP  = kernel/main.cpp core.cpp util.cpp trace.cpp klog.cpp cli.cpp kernel_
                 ui/fb.cpp ui/splash.cpp ui/display.cpp ui/operator_api.cpp \
                 ui/ui_builder_tsv.cpp machine/machine_registry.cpp machine/machine_topology.cpp machine/runtime_placement.cpp machine/motion_wiring.cpp automation/macro_runtime.cpp automation/ladder_runtime.cpp automation/probe_runtime.cpp automation/signals.cpp machine/toolpods.cpp machine/pallet.cpp hmi/hmi_service.cpp \
                 cnc/offsets.cpp cnc/programs.cpp cnc/interpreter.cpp cnc/mdi.cpp \
-                cnc/setup.cpp \
+                cnc/setup.cpp cnc/jobs.cpp \
                 render/gles1.cpp render/machine_model.cpp render/kinematic_model.cpp \
                 render/obj_importer.cpp render/obj_registry.cpp render/stl_importer.cpp render/benchmark.cpp \
                 fs/vfs.cpp fs/fat32.cpp fs/fs_fat32.cpp

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CORE_CPP = core.cpp hal.cpp util.cpp trace.cpp klog.cpp cli.cpp kernel_globals.c
             diag/histogram.cpp diag/jitter.cpp diag/cpu_load.cpp \
             rt/base_thread.cpp \
 ui/fb.cpp ui/splash.cpp ui/display.cpp ui/operator_api.cpp \
-             ui/ui_builder_tsv.cpp machine/machine_registry.cpp machine/machine_topology.cpp machine/runtime_placement.cpp machine/motion_wiring.cpp automation/macro_runtime.cpp automation/ladder_runtime.cpp automation/probe_runtime.cpp automation/signals.cpp machine/toolpods.cpp hmi/hmi_service.cpp \
+             ui/ui_builder_tsv.cpp machine/machine_registry.cpp machine/machine_topology.cpp machine/runtime_placement.cpp machine/motion_wiring.cpp automation/macro_runtime.cpp automation/ladder_runtime.cpp automation/probe_runtime.cpp automation/signals.cpp machine/toolpods.cpp machine/pallet.cpp hmi/hmi_service.cpp \
               cnc/offsets.cpp cnc/programs.cpp cnc/interpreter.cpp cnc/mdi.cpp \
               cnc/setup.cpp \
              render/gles1.cpp render/machine_model.cpp render/kinematic_model.cpp \
@@ -172,7 +172,7 @@ CORE_CPP  = kernel/main.cpp core.cpp util.cpp trace.cpp klog.cpp cli.cpp kernel_
                 diag/histogram.cpp diag/jitter.cpp diag/cpu_load.cpp \
                 rt/base_thread.cpp \
                 ui/fb.cpp ui/splash.cpp ui/display.cpp ui/operator_api.cpp \
-                ui/ui_builder_tsv.cpp machine/machine_registry.cpp machine/machine_topology.cpp machine/runtime_placement.cpp machine/motion_wiring.cpp automation/macro_runtime.cpp automation/ladder_runtime.cpp automation/probe_runtime.cpp automation/signals.cpp machine/toolpods.cpp hmi/hmi_service.cpp \
+                ui/ui_builder_tsv.cpp machine/machine_registry.cpp machine/machine_topology.cpp machine/runtime_placement.cpp machine/motion_wiring.cpp automation/macro_runtime.cpp automation/ladder_runtime.cpp automation/probe_runtime.cpp automation/signals.cpp machine/toolpods.cpp machine/pallet.cpp hmi/hmi_service.cpp \
                 cnc/offsets.cpp cnc/programs.cpp cnc/interpreter.cpp cnc/mdi.cpp \
                 cnc/setup.cpp \
                 render/gles1.cpp render/machine_model.cpp render/kinematic_model.cpp \

--- a/cli.cpp
+++ b/cli.cpp
@@ -27,6 +27,7 @@
 #include "machine/machine_registry.hpp"
 #include "machine/motion_wiring.hpp"
 #include "machine/toolpods.hpp"
+#include "machine/pallet.hpp"
 #include "devices/device_db.hpp"
 #include "diag/jitter.hpp"
 #include "diag/cpu_load.hpp"
@@ -1242,6 +1243,90 @@ static int cmd_toolpod_assign(const char* args, kernel::hal::UARTDriverOps* uart
     uart->puts(ok ? "toolpod_assign: ok\n" : "toolpod_assign: failed\n");
     return ok ? 0 : 1;
 }
+
+// --- Lights-out pallet management ---
+static int cmd_pallets(const char*, kernel::hal::UARTDriverOps* uart) {
+    char buf[192];
+    const size_t n = machine::pallet::g_service.pallet_count();
+    const size_t active = machine::pallet::g_service.active_pallet();
+    kernel::util::k_snprintf(buf, sizeof(buf), "pallets: %lu  active=%s\n",
+                             static_cast<unsigned long>(n),
+                             active == SIZE_MAX ? "(none)"
+                                : machine::pallet::g_service.pallet(active)
+                                  ? machine::pallet::g_service.pallet(active)->id : "?");
+    uart->puts(buf);
+    for (size_t i = 0; i < n; ++i) {
+        const auto* pl = machine::pallet::g_service.pallet(i);
+        if (!pl) continue;
+        kernel::util::k_snprintf(buf, sizeof(buf),
+            "[%lu] %s station=%u fixture=%s wcs=%d status=%s prog=%s cycles=%u/%u%s%s\n",
+            static_cast<unsigned long>(i), pl->id,
+            static_cast<unsigned>(pl->station_index),
+            pl->fixture_id[0] ? pl->fixture_id : "-",
+            pl->work_offset_index,
+            machine::pallet::Service::status_name(pl->status),
+            pl->assigned_program[0] ? pl->assigned_program : "-",
+            static_cast<unsigned>(pl->cycles_completed),
+            static_cast<unsigned>(pl->target_cycles),
+            pl->last_message[0] ? "  msg=" : "",
+            pl->last_message[0] ? pl->last_message : "");
+        uart->puts(buf);
+    }
+    return 0;
+}
+
+static int cmd_pallet_status(const char* args, kernel::hal::UARTDriverOps* uart) {
+    // pallet_status <id> <empty|loaded|cutting|done|fault|hold>
+    if (!args || !*args) {
+        uart->puts("usage: pallet_status <id> <empty|loaded|cutting|done|fault|hold>\n");
+        return 1;
+    }
+    const char* p = args;
+    while (*p == ' ') ++p;
+    char id[32];
+    size_t n = 0;
+    while (*p && *p != ' ' && n + 1 < sizeof(id)) id[n++] = *p++;
+    id[n] = '\0';
+    while (*p == ' ') ++p;
+    machine::pallet::PalletStatus s = machine::pallet::PalletStatus::Empty;
+    if (!machine::pallet::Service::parse_status(p, s)) {
+        uart->puts("pallet_status: bad status token\n");
+        return 1;
+    }
+    const bool ok = machine::pallet::g_service.set_status(id, s);
+    uart->puts(ok ? "pallet_status: ok\n" : "pallet_status: failed (unknown id?)\n");
+    return ok ? 0 : 1;
+}
+
+static int cmd_pallet_assign(const char* args, kernel::hal::UARTDriverOps* uart) {
+    // pallet_assign <id> <program.ngc> <wcs-index 0..5>
+    if (!args || !*args) {
+        uart->puts("usage: pallet_assign <id> <program.ngc> <wcs-index>\n");
+        return 1;
+    }
+    const char* p = args;
+    while (*p == ' ') ++p;
+    char id[32];
+    size_t n = 0;
+    while (*p && *p != ' ' && n + 1 < sizeof(id)) id[n++] = *p++;
+    id[n] = '\0';
+    while (*p == ' ') ++p;
+    char prog[64];
+    n = 0;
+    while (*p && *p != ' ' && n + 1 < sizeof(prog)) prog[n++] = *p++;
+    prog[n] = '\0';
+    long wcs = -1;
+    (void)cli_parse_long(p, wcs);
+    size_t idx = 0;
+    if (!machine::pallet::g_service.find_pallet(id, idx)) {
+        uart->puts("pallet_assign: unknown pallet\n");
+        return 1;
+    }
+    const bool ok = machine::pallet::g_service.assign_program(idx, prog, static_cast<int>(wcs));
+    uart->puts(ok ? "pallet_assign: ok\n" : "pallet_assign: failed\n");
+    return ok ? 0 : 1;
+}
+
 
 static int cmd_ui_page(const char* args, kernel::hal::UARTDriverOps* uart) {
     if (!uart) return 1;
@@ -4852,6 +4937,9 @@ CLI::CLI() {
     register_command("symbol_set", cmd_symbol_set, "symbol_set <name> <value> — override a writable machine symbol");
     register_command("ladder_ls", cmd_ladder_ls, "ladder_ls — list loaded ladder rungs");
     register_command("toolpods", cmd_toolpods, "toolpods — list configured physical pods and virtual tool assignments");
+    register_command("pallets", cmd_pallets, "pallets — list pallet roster, status, and assigned program");
+    register_command("pallet_status", cmd_pallet_status, "pallet_status <id> <empty|loaded|cutting|done|fault|hold>");
+    register_command("pallet_assign", cmd_pallet_assign, "pallet_assign <id> <program.ngc> <wcs 0..5> — set per-pallet program + WCS");
     register_command("toolpod_select", cmd_toolpod_select, "toolpod_select <pod> <station> — move/select a physical pod station");
     register_command("toolpod_assign", cmd_toolpod_assign, "toolpod_assign <pod> <station> <virtual_tool> — remap virtual tool onto a physical station");
     register_command("ui_page", cmd_ui_page, "ui_page <id> — switch the active TSV UI page");

--- a/cli.cpp
+++ b/cli.cpp
@@ -1726,16 +1726,25 @@ static int cmd_test(const char* args, kernel::hal::UARTDriverOps* uart) {
         cnc::interp::g_runtime.set_tcp_mode(Runtime::TcpMode::Head);
         const bool got_head = cnc::interp::g_runtime.tcp_mode() == Runtime::TcpMode::Head;
 
+        // Pivot round-trip: set, read, restore.
+        int32_t orig_px = 0, orig_py = 0, orig_pz = 0;
+        cnc::interp::g_runtime.tcp_pivot(orig_px, orig_py, orig_pz);
+        cnc::interp::g_runtime.set_tcp_pivot(1234, -5678, 9000);
+        int32_t got_px = 0, got_py = 0, got_pz = 0;
+        cnc::interp::g_runtime.tcp_pivot(got_px, got_py, got_pz);
+        const bool got_pivot = (got_px == 1234) && (got_py == -5678) && (got_pz == 9000);
+
         // Restore original state so downstream tests aren't perturbed.
+        cnc::interp::g_runtime.set_tcp_pivot(orig_px, orig_py, orig_pz);
         cnc::interp::g_runtime.set_tcp_mode(orig_mode);
         cnc::interp::g_runtime.set_tcp_order(orig_order);
         (void)cnc::interp::g_runtime.set_tcp_active(0, orig_ch0);
 
-        const bool pass = got_on && !got_off && got_bc && got_cb && got_tail && got_head;
-        char buf[120];
+        const bool pass = got_on && !got_off && got_bc && got_cb && got_tail && got_head && got_pivot;
+        char buf[150];
         kernel::util::k_snprintf(buf, sizeof(buf),
-            "tcp test: on=%d off=%d bc=%d cb=%d tail=%d head=%d => %s\n",
-            got_on, got_off, got_bc, got_cb, got_tail, got_head,
+            "tcp test: on=%d off=%d bc=%d cb=%d tail=%d head=%d pivot=%d => %s\n",
+            got_on, got_off, got_bc, got_cb, got_tail, got_head, got_pivot,
             pass ? "PASSED" : "FAILED");
         uart->puts(buf);
         return pass ? 0 : 1;
@@ -3265,18 +3274,22 @@ static int cmd_queue_depth(const char*, kernel::hal::UARTDriverOps* uart) {
 }
 
 static int cmd_tcp(const char* args, kernel::hal::UARTDriverOps* uart) {
-    // tcp                        — show current TCP order/mode + per-channel state.
-    // tcp <ch> <on|off>          — toggle 5-axis Tool-Centre-Point mode on a channel.
-    // tcp order <cb|bc>          — set the head-kinematics rotation composition.
-    // tcp mode  <head|tail>      — head=rotaries on tool, tail=rotaries on table.
+    // tcp                          — show current TCP order/mode/pivot + per-channel state.
+    // tcp <ch> <on|off>            — toggle 5-axis Tool-Centre-Point mode on a channel.
+    // tcp order <cb|bc>            — set the head-kinematics rotation composition.
+    // tcp mode  <head|tail>        — head=rotaries on tool, tail=rotaries on table.
+    // tcp pivot <x> <y> <z>        — set tail-mode pivot (machine-frame axis counts).
     using cnc::interp::Runtime;
     if (!args || !*args) {
-        char buf[160];
+        char buf[200];
         const char* mode_s  = (cnc::interp::g_runtime.tcp_mode()  == Runtime::TcpMode::Head)  ? "head" : "tail";
         const char* order_s = (cnc::interp::g_runtime.tcp_order() == Runtime::TcpOrder::CB)   ? "cb"   : "bc";
+        int32_t px = 0, py = 0, pz = 0;
+        cnc::interp::g_runtime.tcp_pivot(px, py, pz);
         kernel::util::k_snprintf(buf, sizeof(buf),
-            "tcp: mode=%s order=%s\n  ch0=%s ch1=%s\n",
+            "tcp: mode=%s order=%s pivot=(%ld,%ld,%ld)\n  ch0=%s ch1=%s\n",
             mode_s, order_s,
+            static_cast<long>(px), static_cast<long>(py), static_cast<long>(pz),
             cnc::interp::g_runtime.tcp_active(0) ? "on" : "off",
             cnc::interp::g_runtime.tcp_active(1) ? "on" : "off");
         uart->puts(buf);
@@ -3311,16 +3324,33 @@ static int cmd_tcp(const char* args, kernel::hal::UARTDriverOps* uart) {
         }
         if (kernel::util::kstrcmp(p, "tail") == 0) {
             cnc::interp::g_runtime.set_tcp_mode(Runtime::TcpMode::Tail);
-            uart->puts("tcp: mode=tail (NB: tail-kinematics not yet implemented; falls back to head with klog warning)\n");
+            uart->puts("tcp: mode=tail (rotate target around pivot; set pivot via `tcp pivot <x> <y> <z>`)\n");
             return 0;
         }
         uart->puts("tcp: expected head|tail\n");
         return 1;
     }
+    if (kernel::util::kstrncmp(p, "pivot", 5) == 0 && (p[5] == ' ' || p[5] == '\0')) {
+        p += 5;
+        long px = 0, py = 0, pz = 0;
+        if (!cli_parse_long(p, px) || !cli_parse_long(p, py) || !cli_parse_long(p, pz)) {
+            uart->puts("tcp: usage: tcp pivot <x_counts> <y_counts> <z_counts>\n");
+            return 1;
+        }
+        cnc::interp::g_runtime.set_tcp_pivot(static_cast<int32_t>(px),
+                                             static_cast<int32_t>(py),
+                                             static_cast<int32_t>(pz));
+        char buf[120];
+        kernel::util::k_snprintf(buf, sizeof(buf),
+            "tcp: pivot=(%ld,%ld,%ld) counts (machine-frame; used by tail mode)\n",
+            px, py, pz);
+        uart->puts(buf);
+        return 0;
+    }
 
     long ch = 0;
     if (!cli_parse_long(p, ch)) {
-        uart->puts("usage: tcp [order cb|bc] [mode head|tail] | tcp <ch> on|off\n");
+        uart->puts("usage: tcp [order cb|bc] [mode head|tail] [pivot x y z] | tcp <ch> on|off\n");
         return 1;
     }
     while (*p == ' ') ++p;
@@ -5210,7 +5240,7 @@ CLI::CLI() {
     register_command("tq", cmd_torque_limit, "tq <axis> <permille> — set CiA-402 0x6072 max-torque on the axis's drive");
     register_command("junction_dev", cmd_junction_dev, "junction_dev [<ch> <counts>] — get/set per-channel corner-error budget");
     register_command("queue_depth", cmd_queue_depth, "queue_depth — dump per-channel look-ahead chain occupancy");
-    register_command("tcp", cmd_tcp, "tcp [order cb|bc | mode head|tail | <ch> on|off] — 5-axis TCP control");
+    register_command("tcp", cmd_tcp, "tcp [order cb|bc | mode head|tail | pivot x y z | <ch> on|off] — 5-axis TCP control");
     register_command("topology", cmd_topology, "topology <name>=<ax,ax,...> [...] — rewrite axis-to-channel binding (9.8)");
     register_command("override", cmd_override, "override <ch> <feed|rapid|spindle> <permille> — per-channel speed override (9.7)");
     register_command("gears", cmd_gears, "List active electronic-gear links (9.5) + phase error (9.9)");

--- a/cli.cpp
+++ b/cli.cpp
@@ -1714,11 +1714,20 @@ static int cmd_test(const char* args, kernel::hal::UARTDriverOps* uart) {
         (void)cnc::interp::g_runtime.set_tcp_active(0, false);
         const bool got_off = cnc::interp::g_runtime.tcp_active(0);
 
-        // Cycle order CB → BC → CB.
-        cnc::interp::g_runtime.set_tcp_order(Runtime::TcpOrder::BC);
-        const bool got_bc = cnc::interp::g_runtime.tcp_order() == Runtime::TcpOrder::BC;
+        // Walk every order — round-trip each one.
+        const Runtime::TcpOrder orders[] = {
+            Runtime::TcpOrder::CB, Runtime::TcpOrder::BC,
+            Runtime::TcpOrder::CA, Runtime::TcpOrder::AC,
+            Runtime::TcpOrder::BA, Runtime::TcpOrder::AB,
+        };
+        bool got_orders = true;
+        for (auto o : orders) {
+            cnc::interp::g_runtime.set_tcp_order(o);
+            if (cnc::interp::g_runtime.tcp_order() != o) { got_orders = false; break; }
+        }
         cnc::interp::g_runtime.set_tcp_order(Runtime::TcpOrder::CB);
         const bool got_cb = cnc::interp::g_runtime.tcp_order() == Runtime::TcpOrder::CB;
+        const bool got_bc = got_orders;  // any order failure flagged via this
 
         // Cycle mode head → tail → head.
         cnc::interp::g_runtime.set_tcp_mode(Runtime::TcpMode::Tail);
@@ -3283,7 +3292,16 @@ static int cmd_tcp(const char* args, kernel::hal::UARTDriverOps* uart) {
     if (!args || !*args) {
         char buf[200];
         const char* mode_s  = (cnc::interp::g_runtime.tcp_mode()  == Runtime::TcpMode::Head)  ? "head" : "tail";
-        const char* order_s = (cnc::interp::g_runtime.tcp_order() == Runtime::TcpOrder::CB)   ? "cb"   : "bc";
+        const char* order_s;
+        switch (cnc::interp::g_runtime.tcp_order()) {
+            case Runtime::TcpOrder::CB: order_s = "cb"; break;
+            case Runtime::TcpOrder::BC: order_s = "bc"; break;
+            case Runtime::TcpOrder::CA: order_s = "ca"; break;
+            case Runtime::TcpOrder::AC: order_s = "ac"; break;
+            case Runtime::TcpOrder::BA: order_s = "ba"; break;
+            case Runtime::TcpOrder::AB: order_s = "ab"; break;
+            default: order_s = "?"; break;
+        }
         int32_t px = 0, py = 0, pz = 0;
         cnc::interp::g_runtime.tcp_pivot(px, py, pz);
         kernel::util::k_snprintf(buf, sizeof(buf),
@@ -3301,18 +3319,20 @@ static int cmd_tcp(const char* args, kernel::hal::UARTDriverOps* uart) {
     if (kernel::util::kstrncmp(p, "order", 5) == 0 && (p[5] == ' ' || p[5] == '\0')) {
         p += 5;
         while (*p == ' ') ++p;
-        if (kernel::util::kstrcmp(p, "cb") == 0) {
-            cnc::interp::g_runtime.set_tcp_order(Runtime::TcpOrder::CB);
-            uart->puts("tcp: order=cb (R = R_C * R_B)\n");
-            return 0;
-        }
-        if (kernel::util::kstrcmp(p, "bc") == 0) {
-            cnc::interp::g_runtime.set_tcp_order(Runtime::TcpOrder::BC);
-            uart->puts("tcp: order=bc (R = R_B * R_C)\n");
-            return 0;
-        }
-        uart->puts("tcp: expected cb|bc\n");
-        return 1;
+        Runtime::TcpOrder ord = Runtime::TcpOrder::CB;
+        const char* desc = nullptr;
+        if      (kernel::util::kstrcmp(p, "cb") == 0) { ord = Runtime::TcpOrder::CB; desc = "(R = R_C * R_B)"; }
+        else if (kernel::util::kstrcmp(p, "bc") == 0) { ord = Runtime::TcpOrder::BC; desc = "(R = R_B * R_C)"; }
+        else if (kernel::util::kstrcmp(p, "ca") == 0) { ord = Runtime::TcpOrder::CA; desc = "(R = R_C * R_A)"; }
+        else if (kernel::util::kstrcmp(p, "ac") == 0) { ord = Runtime::TcpOrder::AC; desc = "(R = R_A * R_C)"; }
+        else if (kernel::util::kstrcmp(p, "ba") == 0) { ord = Runtime::TcpOrder::BA; desc = "(R = R_B * R_A)"; }
+        else if (kernel::util::kstrcmp(p, "ab") == 0) { ord = Runtime::TcpOrder::AB; desc = "(R = R_A * R_B)"; }
+        else { uart->puts("tcp: expected cb|bc|ca|ac|ba|ab\n"); return 1; }
+        cnc::interp::g_runtime.set_tcp_order(ord);
+        char buf[64];
+        kernel::util::k_snprintf(buf, sizeof(buf), "tcp: order=%s %s\n", p, desc);
+        uart->puts(buf);
+        return 0;
     }
     if (kernel::util::kstrncmp(p, "mode", 4) == 0 && (p[4] == ' ' || p[4] == '\0')) {
         p += 4;
@@ -5240,7 +5260,7 @@ CLI::CLI() {
     register_command("tq", cmd_torque_limit, "tq <axis> <permille> — set CiA-402 0x6072 max-torque on the axis's drive");
     register_command("junction_dev", cmd_junction_dev, "junction_dev [<ch> <counts>] — get/set per-channel corner-error budget");
     register_command("queue_depth", cmd_queue_depth, "queue_depth — dump per-channel look-ahead chain occupancy");
-    register_command("tcp", cmd_tcp, "tcp [order cb|bc | mode head|tail | pivot x y z | <ch> on|off] — 5-axis TCP control");
+    register_command("tcp", cmd_tcp, "tcp [order cb|bc|ca|ac|ba|ab | mode head|tail | pivot x y z | <ch> on|off] — 5-axis TCP control");
     register_command("topology", cmd_topology, "topology <name>=<ax,ax,...> [...] — rewrite axis-to-channel binding (9.8)");
     register_command("override", cmd_override, "override <ch> <feed|rapid|spindle> <permille> — per-channel speed override (9.7)");
     register_command("gears", cmd_gears, "List active electronic-gear links (9.5) + phase error (9.9)");

--- a/cli.cpp
+++ b/cli.cpp
@@ -29,6 +29,7 @@
 #include "machine/toolpods.hpp"
 #include "machine/pallet.hpp"
 #include "cnc/jobs.hpp"
+#include "fs/vfs.hpp"
 #include "devices/device_db.hpp"
 #include "diag/jitter.hpp"
 #include "diag/cpu_load.hpp"
@@ -1580,6 +1581,13 @@ static int cmd_test(const char* args, kernel::hal::UARTDriverOps* uart) {
         uart->puts("  motion   - test motion kernel dumps\n");
         uart->puts("  ec       - test EtherCAT dumps\n");
         uart->puts("  devices  - test device DB dump\n");
+        uart->puts("  chain    - look-ahead chain ring smoke\n");
+        uart->puts("  mtl      - MTL parser smoke\n");
+        uart->puts("  fake_sdo - fake-slave SDO history smoke\n");
+        uart->puts("  tcp      - TCP modal + rotation-order round-trip\n");
+        uart->puts("  pallet   - pallet roster + status mutation\n");
+        uart->puts("  jobs     - job scheduler state-machine smoke\n");
+        uart->puts("  all      - run every subtest and emit a summary\n");
         return 1;
     }
     if (kernel::util::kstrcmp(args, "status") == 0) {
@@ -1691,12 +1699,133 @@ static int cmd_test(const char* args, kernel::hal::UARTDriverOps* uart) {
         uart->puts(buf);
         return pass ? 0 : 1;
     }
+    if (kernel::util::kstrcmp(args, "tcp") == 0) {
+        // 5-axis TCP modal + rotation-order knob round-trip. No motion is
+        // commanded — the test only checks that flipping the operator
+        // surface lands in the runtime state and reads back unchanged.
+        using cnc::interp::Runtime;
+        const auto orig_mode  = cnc::interp::g_runtime.tcp_mode();
+        const auto orig_order = cnc::interp::g_runtime.tcp_order();
+        const bool orig_ch0   = cnc::interp::g_runtime.tcp_active(0);
+
+        // Toggle ch0 on/off and verify get matches set.
+        (void)cnc::interp::g_runtime.set_tcp_active(0, true);
+        const bool got_on  = cnc::interp::g_runtime.tcp_active(0);
+        (void)cnc::interp::g_runtime.set_tcp_active(0, false);
+        const bool got_off = cnc::interp::g_runtime.tcp_active(0);
+
+        // Cycle order CB → BC → CB.
+        cnc::interp::g_runtime.set_tcp_order(Runtime::TcpOrder::BC);
+        const bool got_bc = cnc::interp::g_runtime.tcp_order() == Runtime::TcpOrder::BC;
+        cnc::interp::g_runtime.set_tcp_order(Runtime::TcpOrder::CB);
+        const bool got_cb = cnc::interp::g_runtime.tcp_order() == Runtime::TcpOrder::CB;
+
+        // Cycle mode head → tail → head.
+        cnc::interp::g_runtime.set_tcp_mode(Runtime::TcpMode::Tail);
+        const bool got_tail = cnc::interp::g_runtime.tcp_mode() == Runtime::TcpMode::Tail;
+        cnc::interp::g_runtime.set_tcp_mode(Runtime::TcpMode::Head);
+        const bool got_head = cnc::interp::g_runtime.tcp_mode() == Runtime::TcpMode::Head;
+
+        // Restore original state so downstream tests aren't perturbed.
+        cnc::interp::g_runtime.set_tcp_mode(orig_mode);
+        cnc::interp::g_runtime.set_tcp_order(orig_order);
+        (void)cnc::interp::g_runtime.set_tcp_active(0, orig_ch0);
+
+        const bool pass = got_on && !got_off && got_bc && got_cb && got_tail && got_head;
+        char buf[120];
+        kernel::util::k_snprintf(buf, sizeof(buf),
+            "tcp test: on=%d off=%d bc=%d cb=%d tail=%d head=%d => %s\n",
+            got_on, got_off, got_bc, got_cb, got_tail, got_head,
+            pass ? "PASSED" : "FAILED");
+        uart->puts(buf);
+        return pass ? 0 : 1;
+    }
+    if (kernel::util::kstrcmp(args, "pallet") == 0) {
+        // Pallet roster loaded from devices/embedded_pallets.tsv at boot.
+        // Verify (a) at least one pallet present, (b) status mutation
+        // round-trips through find_pallet → set_status → pallet, and
+        // (c) next_loaded_after wraps the roster correctly.
+        const size_t n = machine::pallet::g_service.pallet_count();
+        size_t idx = 0;
+        const bool found = machine::pallet::g_service.find_pallet("P01", idx);
+        bool round_trip = false;
+        machine::pallet::PalletStatus orig = machine::pallet::PalletStatus::Empty;
+        if (found) {
+            orig = machine::pallet::g_service.pallet(idx)->status;
+            (void)machine::pallet::g_service.set_status(idx,
+                machine::pallet::PalletStatus::Hold);
+            round_trip = machine::pallet::g_service.pallet(idx)->status ==
+                         machine::pallet::PalletStatus::Hold;
+            (void)machine::pallet::g_service.set_status(idx, orig);
+        }
+        // next_loaded_after on an empty roster (or all-Hold) must return
+        // SIZE_MAX, not loop forever — this is the bit the scheduler
+        // depends on for "queue drained" detection.
+        const size_t any = machine::pallet::g_service.next_loaded_after(0);
+
+        const bool pass = (n > 0) && found && round_trip;
+        char buf[160];
+        kernel::util::k_snprintf(buf, sizeof(buf),
+            "pallet test: count=%zu found=%d roundtrip=%d any_loaded=%s => %s\n",
+            n, found, round_trip,
+            any == SIZE_MAX ? "no" : "yes",
+            pass ? "PASSED" : "FAILED");
+        uart->puts(buf);
+        return pass ? 0 : 1;
+    }
+    if (kernel::util::kstrcmp(args, "jobs") == 0) {
+        // Job scheduler state-machine smoke. Loaded from embedded_jobs.tsv;
+        // verify (a) the queue is non-empty, (b) start→pause→resume
+        // transitions round-trip, (c) start_scheduler is idempotent.
+        const size_t n = cnc::jobs::g_runtime.job_count();
+        const auto orig = cnc::jobs::g_runtime.state();
+
+        cnc::jobs::g_runtime.stop_scheduler();
+        // From Stopped, start_scheduler is rejected by design (operator
+        // must reload the queue). Verify the rejection path.
+        const bool start_after_stop_rejected = !cnc::jobs::g_runtime.start_scheduler();
+        // Force back to Idle by simulating a load (no public API for that;
+        // we round-trip via Holding / Idle which the public verbs cover).
+        // From Stopped, transition to Holding is not allowed either, so
+        // the only way back is to re-load the queue. We accept Stopped
+        // as a terminal state and just restore via direct interface.
+        // For the test we only care about transitions reachable from
+        // outside Stopped, so rebuild Idle by calling load_tsv on the
+        // empty buffer (works because load_tsv resets state_ to Idle).
+        (void)cnc::jobs::g_runtime.load_tsv("\n", 1);  // resets to Idle, empty queue
+        const bool now_idle = cnc::jobs::g_runtime.state() == cnc::jobs::SchedulerState::Idle;
+        const bool started  = cnc::jobs::g_runtime.start_scheduler();
+        const bool running  = cnc::jobs::g_runtime.state() == cnc::jobs::SchedulerState::Running;
+        const bool paused   = cnc::jobs::g_runtime.pause_scheduler();
+        const bool holding  = cnc::jobs::g_runtime.state() == cnc::jobs::SchedulerState::Holding;
+        const bool resumed  = cnc::jobs::g_runtime.resume_scheduler();
+        const bool back     = cnc::jobs::g_runtime.state() == cnc::jobs::SchedulerState::Running;
+        cnc::jobs::g_runtime.stop_scheduler();
+
+        // Restore the seeded queue so downstream operator use isn't broken.
+        const char* jb_data = nullptr; size_t jb_len = 0;
+        if (kernel::vfs::lookup("system/machine/embedded_jobs.tsv", jb_data, jb_len) && jb_len > 0) {
+            (void)cnc::jobs::g_runtime.load_tsv(jb_data, jb_len);
+        }
+        (void)orig;  // we deliberately leave the runtime back at Idle / Loaded
+
+        const bool pass = (n >= 0) && start_after_stop_rejected && now_idle &&
+                          started && running && paused && holding && resumed && back;
+        char buf[200];
+        kernel::util::k_snprintf(buf, sizeof(buf),
+            "jobs test: count=%zu rej=%d idle=%d run=%d hold=%d back=%d => %s\n",
+            n, start_after_stop_rejected, now_idle, running, holding, back,
+            pass ? "PASSED" : "FAILED");
+        uart->puts(buf);
+        return pass ? 0 : 1;
+    }
     if (kernel::util::kstrcmp(args, "all") == 0) {
         // CI-grep target. Runs every subtest and emits a consolidated
         // summary "Tests completed: <total>, <failed> failed".
         const char* subtests[] = {
             "status", "motion", "ec", "devices",
             "chain", "mtl", "fake_sdo",
+            "tcp", "pallet", "jobs",
         };
         size_t failed = 0;
         for (const char* s : subtests) {

--- a/cli.cpp
+++ b/cli.cpp
@@ -28,6 +28,7 @@
 #include "machine/motion_wiring.hpp"
 #include "machine/toolpods.hpp"
 #include "machine/pallet.hpp"
+#include "cnc/jobs.hpp"
 #include "devices/device_db.hpp"
 #include "diag/jitter.hpp"
 #include "diag/cpu_load.hpp"
@@ -1324,6 +1325,88 @@ static int cmd_pallet_assign(const char* args, kernel::hal::UARTDriverOps* uart)
     }
     const bool ok = machine::pallet::g_service.assign_program(idx, prog, static_cast<int>(wcs));
     uart->puts(ok ? "pallet_assign: ok\n" : "pallet_assign: failed\n");
+    return ok ? 0 : 1;
+}
+
+// --- Job scheduler ---
+static const char* job_state_name(cnc::jobs::JobState s) {
+    switch (s) {
+        case cnc::jobs::JobState::Pending: return "pending";
+        case cnc::jobs::JobState::Running: return "running";
+        case cnc::jobs::JobState::Done:    return "done";
+        case cnc::jobs::JobState::Faulted: return "faulted";
+        case cnc::jobs::JobState::Skipped: return "skipped";
+    }
+    return "?";
+}
+
+static const char* sched_state_name(cnc::jobs::SchedulerState s) {
+    switch (s) {
+        case cnc::jobs::SchedulerState::Idle:    return "idle";
+        case cnc::jobs::SchedulerState::Running: return "running";
+        case cnc::jobs::SchedulerState::Holding: return "holding";
+        case cnc::jobs::SchedulerState::Stopped: return "stopped";
+    }
+    return "?";
+}
+
+static int cmd_jobs(const char*, kernel::hal::UARTDriverOps* uart) {
+    char buf[224];
+    const size_t active = cnc::jobs::g_runtime.active_job();
+    kernel::util::k_snprintf(buf, sizeof(buf),
+        "scheduler: %s  jobs=%lu  active=%s\n",
+        sched_state_name(cnc::jobs::g_runtime.state()),
+        static_cast<unsigned long>(cnc::jobs::g_runtime.job_count()),
+        active == SIZE_MAX ? "(none)"
+            : (cnc::jobs::g_runtime.job(active) ? cnc::jobs::g_runtime.job(active)->id : "?"));
+    uart->puts(buf);
+    for (size_t i = 0; i < cnc::jobs::g_runtime.job_count(); ++i) {
+        const auto* j = cnc::jobs::g_runtime.job(i);
+        if (!j) continue;
+        kernel::util::k_snprintf(buf, sizeof(buf),
+            "[%lu] %s pri=%u pallet=%s prog=%s wcs=%d state=%s done=%u/%u%s%s\n",
+            static_cast<unsigned long>(i), j->id, static_cast<unsigned>(j->priority),
+            j->pallet_id[0] ? j->pallet_id : "-",
+            j->program[0] ? j->program : "-",
+            j->work_offset_index,
+            job_state_name(j->state),
+            static_cast<unsigned>(j->completed), static_cast<unsigned>(j->repeat),
+            j->last_message[0] ? "  msg=" : "",
+            j->last_message[0] ? j->last_message : "");
+        uart->puts(buf);
+    }
+    return 0;
+}
+
+static int cmd_job_run(const char*, kernel::hal::UARTDriverOps* uart) {
+    const bool ok = cnc::jobs::g_runtime.start_scheduler();
+    uart->puts(ok ? "scheduler: started\n" : "scheduler: cannot start (stopped — reload to reset)\n");
+    return ok ? 0 : 1;
+}
+
+static int cmd_job_pause(const char*, kernel::hal::UARTDriverOps* uart) {
+    const bool ok = cnc::jobs::g_runtime.pause_scheduler();
+    uart->puts(ok ? "scheduler: holding (will idle after current job)\n"
+                  : "scheduler: cannot pause (not running)\n");
+    return ok ? 0 : 1;
+}
+
+static int cmd_job_resume(const char*, kernel::hal::UARTDriverOps* uart) {
+    const bool ok = cnc::jobs::g_runtime.resume_scheduler();
+    uart->puts(ok ? "scheduler: resumed\n" : "scheduler: cannot resume (not holding)\n");
+    return ok ? 0 : 1;
+}
+
+static int cmd_job_skip(const char*, kernel::hal::UARTDriverOps* uart) {
+    const bool ok = cnc::jobs::g_runtime.skip_current();
+    uart->puts(ok ? "scheduler: current job skipped\n" : "scheduler: no active job\n");
+    return ok ? 0 : 1;
+}
+
+static int cmd_job_abort(const char*, kernel::hal::UARTDriverOps* uart) {
+    const bool ok = cnc::jobs::g_runtime.abort_current();
+    uart->puts(ok ? "scheduler: current job aborted; queue holding\n"
+                  : "scheduler: no active job\n");
     return ok ? 0 : 1;
 }
 
@@ -4940,6 +5023,12 @@ CLI::CLI() {
     register_command("pallets", cmd_pallets, "pallets — list pallet roster, status, and assigned program");
     register_command("pallet_status", cmd_pallet_status, "pallet_status <id> <empty|loaded|cutting|done|fault|hold>");
     register_command("pallet_assign", cmd_pallet_assign, "pallet_assign <id> <program.ngc> <wcs 0..5> — set per-pallet program + WCS");
+    register_command("jobs",       cmd_jobs,       "jobs — list lights-out job queue + scheduler state");
+    register_command("job_run",    cmd_job_run,    "job_run — start the scheduler (Idle → Running)");
+    register_command("job_pause",  cmd_job_pause,  "job_pause — Running → Holding (settles to Idle after current job)");
+    register_command("job_resume", cmd_job_resume, "job_resume — Holding → Running");
+    register_command("job_skip",   cmd_job_skip,   "job_skip — mark current job Skipped, advance");
+    register_command("job_abort",  cmd_job_abort,  "job_abort — stop interpreter on current job, queue → Holding");
     register_command("toolpod_select", cmd_toolpod_select, "toolpod_select <pod> <station> — move/select a physical pod station");
     register_command("toolpod_assign", cmd_toolpod_assign, "toolpod_assign <pod> <station> <virtual_tool> — remap virtual tool onto a physical station");
     register_command("ui_page", cmd_ui_page, "ui_page <id> — switch the active TSV UI page");

--- a/cli.cpp
+++ b/cli.cpp
@@ -1809,7 +1809,7 @@ static int cmd_test(const char* args, kernel::hal::UARTDriverOps* uart) {
         }
         (void)orig;  // we deliberately leave the runtime back at Idle / Loaded
 
-        const bool pass = (n >= 0) && start_after_stop_rejected && now_idle &&
+        const bool pass = start_after_stop_rejected && now_idle &&
                           started && running && paused && holding && resumed && back;
         char buf[200];
         kernel::util::k_snprintf(buf, sizeof(buf),

--- a/cli.cpp
+++ b/cli.cpp
@@ -1662,6 +1662,62 @@ static int cmd_axis_load_calibrate(const char* args, kernel::hal::UARTDriverOps*
 static int cmd_barriers(const char*, kernel::hal::UARTDriverOps* uart) {
     motion::g_motion.dump_barriers(uart); return 0;
 }
+// One-shot mill-turn sync dashboard: per-channel state + override permilles
+// + interpreter snapshot + active barriers, all in a frame an operator can
+// scan without piecing together output from `channels`, `barriers`, and
+// `program_status`. Read-only.
+static int cmd_sync_status(const char*, kernel::hal::UARTDriverOps* uart) {
+    char buf[200];
+    uart->puts("--- sync_status ---\n");
+    for (size_t c = 0; c < motion::g_motion.channel_count(); ++c) {
+        const auto& ch = motion::g_motion.channel(c);
+        const char* state = "?";
+        switch (ch.state) {
+            case motion::ChannelState::Idle:           state = "idle";    break;
+            case motion::ChannelState::Running:        state = "running"; break;
+            case motion::ChannelState::FeedHold:       state = "hold";    break;
+            case motion::ChannelState::WaitingBarrier: state = "barrier"; break;
+            case motion::ChannelState::Gearing:        state = "gearing"; break;
+            case motion::ChannelState::Fault:          state = "fault";   break;
+        }
+        kernel::util::k_snprintf(buf, sizeof(buf),
+            "ch%zu(%s) state=%s feed=%u%% rapid=%u%% spindle=%u%% jd=%ld\n",
+            c, ch.name, state,
+            (unsigned)(ch.overrides.feed_permille    / 10),
+            (unsigned)(ch.overrides.rapid_permille   / 10),
+            (unsigned)(ch.overrides.spindle_permille / 10),
+            static_cast<long>(ch.overrides.junction_deviation_counts));
+        uart->puts(buf);
+        const auto snap = cnc::interp::g_runtime.snapshot(c);
+        const char* istate = "?";
+        switch (snap.state) {
+            case cnc::interp::State::Idle:            istate = "idle";       break;
+            case cnc::interp::State::Ready:           istate = "ready";      break;
+            case cnc::interp::State::Running:         istate = "running";    break;
+            case cnc::interp::State::WaitingBarrier:  istate = "barrier";    break;
+            case cnc::interp::State::WaitingMacro:    istate = "macro";      break;
+            case cnc::interp::State::Dwell:           istate = "dwell";      break;
+            case cnc::interp::State::Complete:        istate = "complete";   break;
+            case cnc::interp::State::Fault:           istate = "fault";      break;
+        }
+        kernel::util::k_snprintf(buf, sizeof(buf),
+            "  prog=%s line=%zu block=%zu interp=%s feed=%u spindle=%ld%s\n",
+            snap.program_name, snap.line, snap.block, istate,
+            snap.feed, static_cast<long>(snap.spindle),
+            snap.tool_length_active ? " G43" : "");
+        uart->puts(buf);
+        if (snap.barrier_token != 0) {
+            kernel::util::k_snprintf(buf, sizeof(buf),
+                "  waiting on token=0x%04x mask=0x%02x\n",
+                static_cast<unsigned>(snap.barrier_token),
+                static_cast<unsigned>(snap.barrier_mask));
+            uart->puts(buf);
+        }
+    }
+    uart->puts("--- barriers ---\n");
+    motion::g_motion.dump_barriers(uart);
+    return 0;
+}
 static int cmd_gears(const char*, kernel::hal::UARTDriverOps* uart) {
     motion::g_motion.dump_gears(uart); return 0;
 }
@@ -4841,6 +4897,7 @@ CLI::CLI() {
     register_command("axis_load_calibrate", cmd_axis_load_calibrate,
         "axis_load_calibrate <axis>");
     register_command("barriers", cmd_barriers, "List active cross-channel barriers (9.4)");
+    register_command("sync_status", cmd_sync_status, "Mill-turn sync dashboard: per-channel state, overrides, interpreter snap, barriers");
     register_command("barrier_arrive", cmd_barrier_arrive, "barrier_arrive <ch> <token-hex> <parts-mask-hex> [tol] [stable] [maxw]");
     register_command("sync_move", cmd_sync_move, "sync_move <mask-hex> <ax> <tgt> [<ax> <tgt> ...] — cross-channel coordinated move (9.6)");
     register_command("feedhold", cmd_feedhold, "feedhold <ch> <0|1> — per-channel pause/resume (9.7)");

--- a/cli.cpp
+++ b/cli.cpp
@@ -2912,15 +2912,62 @@ static int cmd_queue_depth(const char*, kernel::hal::UARTDriverOps* uart) {
 }
 
 static int cmd_tcp(const char* args, kernel::hal::UARTDriverOps* uart) {
-    // tcp <ch> <on|off>  — toggle 5-axis Tool-Centre-Point mode.
+    // tcp                        — show current TCP order/mode + per-channel state.
+    // tcp <ch> <on|off>          — toggle 5-axis Tool-Centre-Point mode on a channel.
+    // tcp order <cb|bc>          — set the head-kinematics rotation composition.
+    // tcp mode  <head|tail>      — head=rotaries on tool, tail=rotaries on table.
+    using cnc::interp::Runtime;
     if (!args || !*args) {
-        uart->puts("usage: tcp <channel> <on|off>\n");
-        return 1;
+        char buf[160];
+        const char* mode_s  = (cnc::interp::g_runtime.tcp_mode()  == Runtime::TcpMode::Head)  ? "head" : "tail";
+        const char* order_s = (cnc::interp::g_runtime.tcp_order() == Runtime::TcpOrder::CB)   ? "cb"   : "bc";
+        kernel::util::k_snprintf(buf, sizeof(buf),
+            "tcp: mode=%s order=%s\n  ch0=%s ch1=%s\n",
+            mode_s, order_s,
+            cnc::interp::g_runtime.tcp_active(0) ? "on" : "off",
+            cnc::interp::g_runtime.tcp_active(1) ? "on" : "off");
+        uart->puts(buf);
+        return 0;
     }
     const char* p = args;
+    while (*p == ' ') ++p;
+
+    if (kernel::util::kstrncmp(p, "order", 5) == 0 && (p[5] == ' ' || p[5] == '\0')) {
+        p += 5;
+        while (*p == ' ') ++p;
+        if (kernel::util::kstrcmp(p, "cb") == 0) {
+            cnc::interp::g_runtime.set_tcp_order(Runtime::TcpOrder::CB);
+            uart->puts("tcp: order=cb (R = R_C * R_B)\n");
+            return 0;
+        }
+        if (kernel::util::kstrcmp(p, "bc") == 0) {
+            cnc::interp::g_runtime.set_tcp_order(Runtime::TcpOrder::BC);
+            uart->puts("tcp: order=bc (R = R_B * R_C)\n");
+            return 0;
+        }
+        uart->puts("tcp: expected cb|bc\n");
+        return 1;
+    }
+    if (kernel::util::kstrncmp(p, "mode", 4) == 0 && (p[4] == ' ' || p[4] == '\0')) {
+        p += 4;
+        while (*p == ' ') ++p;
+        if (kernel::util::kstrcmp(p, "head") == 0) {
+            cnc::interp::g_runtime.set_tcp_mode(Runtime::TcpMode::Head);
+            uart->puts("tcp: mode=head\n");
+            return 0;
+        }
+        if (kernel::util::kstrcmp(p, "tail") == 0) {
+            cnc::interp::g_runtime.set_tcp_mode(Runtime::TcpMode::Tail);
+            uart->puts("tcp: mode=tail (NB: tail-kinematics not yet implemented; falls back to head with klog warning)\n");
+            return 0;
+        }
+        uart->puts("tcp: expected head|tail\n");
+        return 1;
+    }
+
     long ch = 0;
     if (!cli_parse_long(p, ch)) {
-        uart->puts("tcp: bad args\n");
+        uart->puts("usage: tcp [order cb|bc] [mode head|tail] | tcp <ch> on|off\n");
         return 1;
     }
     while (*p == ' ') ++p;
@@ -4800,7 +4847,7 @@ CLI::CLI() {
     register_command("tq", cmd_torque_limit, "tq <axis> <permille> — set CiA-402 0x6072 max-torque on the axis's drive");
     register_command("junction_dev", cmd_junction_dev, "junction_dev [<ch> <counts>] — get/set per-channel corner-error budget");
     register_command("queue_depth", cmd_queue_depth, "queue_depth — dump per-channel look-ahead chain occupancy");
-    register_command("tcp", cmd_tcp, "tcp <ch> <on|off> — toggle 5-axis Tool-Centre-Point mode");
+    register_command("tcp", cmd_tcp, "tcp [order cb|bc | mode head|tail | <ch> on|off] — 5-axis TCP control");
     register_command("topology", cmd_topology, "topology <name>=<ax,ax,...> [...] — rewrite axis-to-channel binding (9.8)");
     register_command("override", cmd_override, "override <ch> <feed|rapid|spindle> <permille> — per-channel speed override (9.7)");
     register_command("gears", cmd_gears, "List active electronic-gear links (9.5) + phase error (9.9)");

--- a/cnc/interpreter.cpp
+++ b/cnc/interpreter.cpp
@@ -641,45 +641,68 @@ static int32_t tool_length_counts(const Runtime::ChannelState& state, char word)
     }
 }
 
-// Tool-tip → spindle-reference transform for 5-axis TCP. Composes a
-// head-kinematics rotation of the tool vector and subtracts it from the
-// requested tool-tip target so the X/Y/Z axes drive the spindle to the
-// position that puts the tip at the requested point.
+// Apply the rotation R(β, γ) to (vx, vy, vz). β = pitch about Y (B),
+// γ = yaw about Z (C). order picks composition: CB applies R_B then R_C
+// (R = R_C · R_B); BC applies R_C then R_B (R = R_B · R_C). Sign of cb
+// / sb / cc / sc is built in by the caller — passing negated angles
+// computes R^-1 (== R^T for orthogonal R), used by tail mode.
+static void rotate_bc(float vx, float vy, float vz,
+                      float cb, float sb, float cc, float sc,
+                      Runtime::TcpOrder order,
+                      float& ox, float& oy, float& oz) {
+    if (order == Runtime::TcpOrder::CB) {
+        const float xb =  vx * cb + vz * sb;
+        const float yb =  vy;
+        const float zb = -vx * sb + vz * cb;
+        ox = xb * cc - yb * sc;
+        oy = xb * sc + yb * cc;
+        oz = zb;
+    } else {
+        const float xc =  vx * cc - vy * sc;
+        const float yc =  vx * sc + vy * cc;
+        const float zc =  vz;
+        ox =  xc * cb + zc * sb;
+        oy =  yc;
+        oz = -xc * sb + zc * cb;
+    }
+}
+
+// 5-axis TCP target correction.
 //
 // Rotary targets[B] / targets[C] are expected in axis counts; conversion
-// to radians uses the kernel's 100 cnt/degree convention. Linear length
-// components are in axis counts (already pre-scaled into
-// state.tool_length_*_counts at G43 time).
+// to radians uses the kernel's 100 cnt/degree convention.
 //
 // Convention matches render::kinematic forward kinematics: R_C is yaw
-// around +Z (machine vertical), R_B is pitch around +Y (head tilt). For
-// a typical mill head with a spindle pointing -Z when B = 0 and C = 0
-// and a positive length_z, the tool vector in the machine frame is
-// (0, 0, -length_z), so the spindle reference position equals
-// tool_tip - R · (length_x, length_y, length_z).
+// around +Z (machine vertical), R_B is pitch around +Y (head tilt).
 //
-// Rotation composition is selectable via Runtime::tcp_order():
+// Rotation composition selectable via Runtime::tcp_order():
 //   CB (default) — R = R_C · R_B  (B applied first, then C; matches the
 //                  millturn TSV's C-then-B parent chain).
 //   BC           — R = R_B · R_C  (C applied first, then B; AC/BC heads
 //                  where B is the outer joint).
 //
 // Mode selectable via Runtime::tcp_mode():
-//   Head — rotaries carry the tool. The composition above runs unchanged.
-//   Tail — rotaries carry the workpiece. The relationship between the
-//          requested tool-tip (in workpiece coords) and the machine-frame
-//          target depends on the rotary pivot offset, which today is not
-//          captured in the kinematic_model TSV. Until that lands, Tail
-//          falls through to the Head path and emits a one-shot klog
-//          warning so the operator notices.
+//   Head — rotaries carry the TOOL. The tool vector
+//          (length_x, length_y, length_z) rotates with the head. To put
+//          the tool tip at the requested target, the spindle reference
+//          position is `tip - R · tool_vec`. The G43-scalar Z addition
+//          done in resolve_targets is undone here so it doesn't double-
+//          count.
+//   Tail — rotaries carry the WORKPIECE. The tool sits at fixed machine
+//          coordinates, and a tool-tip target written in workpiece-frame
+//          coordinates needs to be rotated around the pivot point to
+//          give the machine-frame command. The G43 tool-length addition
+//          stays (the tool is in fixed machine coordinates so plain
+//          tool-length comp is correct). The pivot is configured per-
+//          machine via Runtime::set_tcp_pivot — the (X,Y,Z) machine
+//          coordinates of the rotary pivot when both rotaries are at
+//          zero. Default (0,0,0) means "rotaries pivot at workpiece
+//          origin", a clean default for a calibrated G54 setup.
 static void apply_tcp_correction(Runtime::ChannelState& state,
                                  Runtime& runtime,
                                  size_t channel,
                                  int32_t targets[motion::MAX_AXES]) {
     if (!state.tcp_active) return;
-    if (state.tool_length_counts == 0 &&
-        state.tool_length_x_counts == 0 &&
-        state.tool_length_y_counts == 0) return;
     uint8_t x_idx=0, y_idx=0, z_idx=0, b_idx=0, c_idx=0;
     const bool has_xy =
         runtime.resolve_axis_word(channel, 'X', x_idx) &&
@@ -688,27 +711,10 @@ static void apply_tcp_correction(Runtime::ChannelState& state,
     if (!has_xy || !has_z) return;
     const bool has_b = runtime.resolve_axis_word(channel, 'B', b_idx);
     const bool has_c = runtime.resolve_axis_word(channel, 'C', c_idx);
-    if (runtime.tcp_mode() == Runtime::TcpMode::Tail) {
-        // One-shot warning so the operator sees the limitation in klog;
-        // motion still advances using the head path so a multi-axis
-        // toolpath at least retains the rotary correction's primary
-        // contribution. Pivot-offset support lands with the kinematic_
-        // model TSV extension (see CHANNELS.md "TCP" task).
-        static bool warned_once = false;
-        if (!warned_once) {
-            warned_once = true;
-            const char msg[] =
-                "[tcp] tail-kinematics not implemented; falling back to head\n";
-            kernel::klog::record(msg, sizeof(msg) - 1);
-        }
-    }
+
     // Convention: rotary axis counts at 100 cnt/degree → degrees/100 →
     // radians. cos(0)=1, sin(0)=0, so a 3-axis machine with no B/C falls
-    // through with the tool vector unrotated and the correction reduces
-    // to a constant offset on Z (the same effect tool_length_counts
-    // already added in resolve_targets — TCP would double-correct, so
-    // this path subtracts the tool_length component before applying the
-    // rotated correction. Net: TCP supersedes G43 Z-only when active).
+    // through with the rotation reducing to identity.
     const float beta_rad  = has_b
         ? (static_cast<float>(targets[b_idx]) / 100.0f) *
           kernel::util::math::kDegToRad
@@ -719,38 +725,41 @@ static void apply_tcp_correction(Runtime::ChannelState& state,
         : 0.0f;
     const float cb = cos_approx(beta_rad),  sb = sin_approx(beta_rad);
     const float cc = cos_approx(gamma_rad), sc = sin_approx(gamma_rad);
-    const float lx = static_cast<float>(state.tool_length_x_counts);
-    const float ly = static_cast<float>(state.tool_length_y_counts);
-    const float lz = static_cast<float>(state.tool_length_counts);
 
-    float xw, yw, zw;
-    if (runtime.tcp_order() == Runtime::TcpOrder::CB) {
-        // R = R_C · R_B applied to (lx, ly, lz):
-        //   step 1 — R_B (pitch around Y):
-        //   step 2 — R_C (yaw around Z) on the R_B output.
-        const float xb =  lx * cb + lz * sb;
-        const float yb =  ly;
-        const float zb = -lx * sb + lz * cb;
-        xw = xb * cc - yb * sc;
-        yw = xb * sc + yb * cc;
-        zw = zb;
-    } else {
-        // R = R_B · R_C — apply R_C first, then R_B.
-        const float xc =  lx * cc - ly * sc;
-        const float yc =  lx * sc + ly * cc;
-        const float zc =  lz;
-        xw =  xc * cb + zc * sb;
-        yw =  yc;
-        zw = -xc * sb + zc * cb;
+    if (runtime.tcp_mode() == Runtime::TcpMode::Head) {
+        // Head mode: skip if there's no tool vector to rotate (the
+        // correction would be zero anyway).
+        if (state.tool_length_counts == 0 &&
+            state.tool_length_x_counts == 0 &&
+            state.tool_length_y_counts == 0) return;
+        const float lx = static_cast<float>(state.tool_length_x_counts);
+        const float ly = static_cast<float>(state.tool_length_y_counts);
+        const float lz = static_cast<float>(state.tool_length_counts);
+        float xw, yw, zw;
+        rotate_bc(lx, ly, lz, cb, sb, cc, sc, runtime.tcp_order(), xw, yw, zw);
+        // Undo the G43-scalar Z addition that resolve_targets applied
+        // via tool_length_counts() so we don't correct twice.
+        // tool_length_x/y weren't applied (3-axis G43 path is Z-only)
+        // so no undo there.
+        targets[z_idx] -= state.tool_length_counts;
+        targets[x_idx] -= static_cast<int32_t>(xw);
+        targets[y_idx] -= static_cast<int32_t>(yw);
+        targets[z_idx] -= static_cast<int32_t>(zw);
+        return;
     }
-    // Undo the G43-scalar Z addition that resolve_targets applied via
-    // tool_length_counts() so we don't correct twice. tool_length_x/y
-    // weren't applied (3-axis G43 path is Z-only) so no undo there.
-    targets[z_idx] -= state.tool_length_counts;
-    // Apply the rotated tool offset.
-    targets[x_idx] -= static_cast<int32_t>(xw);
-    targets[y_idx] -= static_cast<int32_t>(yw);
-    targets[z_idx] -= static_cast<int32_t>(zw);
+
+    // Tail mode: rotate the requested target around the pivot. The
+    // tool-length comp (G43) stays — spindle is fixed in machine frame.
+    int32_t pivot_x = 0, pivot_y = 0, pivot_z = 0;
+    runtime.tcp_pivot(pivot_x, pivot_y, pivot_z);
+    const float dx = static_cast<float>(targets[x_idx] - pivot_x);
+    const float dy = static_cast<float>(targets[y_idx] - pivot_y);
+    const float dz = static_cast<float>(targets[z_idx] - pivot_z);
+    float rx, ry, rz;
+    rotate_bc(dx, dy, dz, cb, sb, cc, sc, runtime.tcp_order(), rx, ry, rz);
+    targets[x_idx] = pivot_x + static_cast<int32_t>(rx);
+    targets[y_idx] = pivot_y + static_cast<int32_t>(ry);
+    targets[z_idx] = pivot_z + static_cast<int32_t>(rz);
 }
 
 static bool resolve_targets(Runtime::ChannelState& state,

--- a/cnc/interpreter.cpp
+++ b/cnc/interpreter.cpp
@@ -448,10 +448,20 @@ static int32_t units_to_counts(const Runtime::ChannelState& state, float value) 
 // Convert to counts-per-second so the motion kernel's path-velocity clamp
 // can compare like-with-like. Returns 0 when the F-word hasn't been seen
 // (state.feed defaults to 1000 in load_selected, but interpret as mm/min).
-static uint32_t feed_cps_for_state(const Runtime::ChannelState& state) noexcept {
+//
+// The channel's feed override (set via the `override` CLI verb or the HMI
+// slider) scales the resulting cps when state.override_active is true.
+// M48 enables the slider; M49 disables it (treat permille as 1000).
+static uint32_t feed_cps_for_state(const Runtime::ChannelState& state,
+                                   size_t channel) noexcept {
     if (state.feed == 0) return 0;
     const uint64_t scale = state.inch_mode ? 2540u : 100u;
-    return static_cast<uint32_t>((static_cast<uint64_t>(state.feed) * scale) / 60u);
+    uint64_t cps = (static_cast<uint64_t>(state.feed) * scale) / 60u;
+    if (state.override_active && channel < motion::g_motion.channel_count()) {
+        const uint16_t permille = motion::g_motion.channel(channel).overrides.feed_permille;
+        cps = (cps * permille) / 1000u;
+    }
+    return static_cast<uint32_t>(cps);
 }
 
 // Combined-axis Euclidean distance in counts for the participating axes.
@@ -815,7 +825,7 @@ static bool execute_axes(Runtime::ChannelState& state,
     // per spec.
     uint64_t min_t_final_us = 0;
     if (state.motion_mode != MotionMode::Rapid) {
-        const uint32_t feed_cps = feed_cps_for_state(state);
+        const uint32_t feed_cps = feed_cps_for_state(state, channel);
         if (feed_cps > 0) {
             uint32_t path_counts;
             if (state.tcp_active) {
@@ -1004,7 +1014,7 @@ static bool advance_arc(Runtime::ChannelState& state) {
     // surface feedrate regardless of pitch — without this, a 360° helix
     // with 50 mm rise ran arc-only at F and the linear axis was just
     // dragged along, so the actual surface speed went up by sqrt(1 + (rise/circ)²).
-    const uint32_t feed_cps = feed_cps_for_state(state);
+    const uint32_t feed_cps = feed_cps_for_state(state, channel);
     uint64_t min_t_final_us = 0;
     if (feed_cps > 0) {
         const float arc_seg_len =
@@ -1325,13 +1335,36 @@ bool Runtime::tick_channel(size_t channel) noexcept {
             if (speed < 0) speed = -speed;
             if (parsed.m_code == 5) state.spindle = 0;
             else state.spindle = (parsed.m_code == 4) ? -speed : speed;
+            int32_t commanded = (parsed.m_code == 5) ? 0 : state.spindle;
+            // Apply the channel's spindle override when M48 is in effect.
+            if (state.override_active && commanded != 0 &&
+                channel < motion::g_motion.channel_count()) {
+                const uint16_t permille =
+                    motion::g_motion.channel(channel).overrides.spindle_permille;
+                commanded = static_cast<int32_t>(
+                    (static_cast<int64_t>(commanded) * permille) / 1000);
+            }
             motion::g_motion.set_axis_velocity(static_cast<size_t>(spindle_axis),
-                                               parsed.m_code == 5 ? 0 : state.spindle);
+                                               commanded);
         }
         return true;
     }
-    if (parsed.m_code == 100 || parsed.m_code == 110 || parsed.m_code == 200) {
-        const uint16_t token = static_cast<uint16_t>(parsed.p_word >= 0 ? parsed.p_word : (state.line & 0xFFFF));
+    // M48 / M49 — feed/spindle override enable/disable. Modal flag only;
+    // takes effect on the next feed_cps_for_state / spindle dispatch.
+    if (parsed.m_code == 48) { state.override_active = true;  return true; }
+    if (parsed.m_code == 49) { state.override_active = false; return true; }
+    // M100/M110/M200 — historical sync barrier verbs.
+    // M101..M109 — named alternates. Token defaults to (mcode * 1000 + line)
+    // so a program with multiple M101s at different lines doesn't collide
+    // unless P explicitly forces a shared token. Q (participants mask)
+    // defaults to all-channels (0x3 today; 0xFF leaves room for >2).
+    if (parsed.m_code == 100 || parsed.m_code == 110 || parsed.m_code == 200 ||
+        (parsed.m_code >= 101 && parsed.m_code <= 109)) {
+        const long mcode = parsed.m_code;
+        const uint16_t default_token = static_cast<uint16_t>(
+            (mcode * 1000l + static_cast<long>(state.line)) & 0xFFFF);
+        const uint16_t token = static_cast<uint16_t>(
+            parsed.p_word >= 0 ? parsed.p_word : default_token);
         const uint8_t mask = static_cast<uint8_t>(parsed.q_word >= 0 ? parsed.q_word : 0x3);
         const bool ok = motion::g_motion.arrive_at_barrier(channel, token, mask, 1, 3, 20000);
         if (!ok) {

--- a/cnc/interpreter.cpp
+++ b/cnc/interpreter.cpp
@@ -39,6 +39,12 @@ struct ParsedLine {
     bool home = false;
     bool tool_length_enable = false;
     bool tool_length_cancel = false;
+    // G43.4 / G43.5 TCP enable; G49.1 TCP cancel. Routed through the
+    // Runtime::set_tcp_active path so the executor mirrors the operator
+    // CLI verb's effect — keeps the snapshot and the interpreter modal
+    // state coherent regardless of which path flipped it.
+    bool tcp_enable = false;
+    bool tcp_cancel = false;
     long tool_word = -1;
     long h_word = -1;
     long m_code = -1;
@@ -315,6 +321,11 @@ bool Runtime::restart_at_line(size_t channel, size_t target_line) noexcept {
             state.tool_length_x_counts = static_cast<int32_t>(tos.length_x * 100.0f);
             state.tool_length_y_counts = static_cast<int32_t>(tos.length_y * 100.0f);
         }
+        // G43.4 / G49.1 — TCP modal flag mirrors the operator-side toggle so
+        // a dry-scan restart leaves the channel in the same TCP state the
+        // program reached, regardless of which line we resumed from.
+        if (parsed.tcp_cancel) state.tcp_active = false;
+        if (parsed.tcp_enable) state.tcp_active = true;
         // M6 in the source program would physically change the tool, but on
         // a dry scan we only promote the pending index to active so the
         // reconstructed state reflects "this is the tool the program expects".
@@ -478,7 +489,11 @@ static motion::HomingPlan default_homing_plan() {
     return plan;
 }
 
-static void parse_g_word(int code, ParsedLine& parsed) {
+// `frac` is the first decimal digit of the G-code (43.4 → frac=4, 49.1 →
+// frac=1). Most G-codes are integer (frac == 0) and the existing dispatch
+// runs unchanged. Decimal cases (G43.4 / G49.1) route into separate
+// ParsedLine flags so executor logic stays a flat set of if-statements.
+static void parse_g_word(int code, int frac, ParsedLine& parsed) {
     if (code == 0) {
         parsed.set_motion_mode = true;
         parsed.motion_mode = MotionMode::Rapid;
@@ -511,9 +526,16 @@ static void parse_g_word(int code, ParsedLine& parsed) {
     } else if (code == 28) {
         parsed.home = true;
     } else if (code == 43) {
-        parsed.tool_length_enable = true;
+        // G43          — classic tool-length compensation enable.
+        // G43.4 / G43.5 — TCP enable. The active orientation lives on
+        //                 cnc::interp::Runtime::set_tcp_active(channel, true);
+        //                 the rotary axes are read by apply_tcp_correction.
+        if (frac == 4 || frac == 5) parsed.tcp_enable = true;
+        else                        parsed.tool_length_enable = true;
     } else if (code == 49) {
-        parsed.tool_length_cancel = true;
+        // G49   — tool-length comp cancel. G49.1 also cancels TCP.
+        if (frac == 1) parsed.tcp_cancel = true;
+        else           parsed.tool_length_cancel = true;
     } else if (code == 53) {
         parsed.machine_coordinates = true;
     } else if (code >= 54 && code <= 59) {
@@ -539,7 +561,17 @@ static bool parse_line(const char* s, ParsedLine& parsed) {
         if (word == 'N') {
             (void)parse_float_token(s, i);
         } else if (word == 'G') {
-            parse_g_word(static_cast<int>(parse_float_token(s, i)), parsed);
+            // Decimal G-code dispatch (G43.4 / G49.1 / G33.1 / ...). The
+            // integer part picks the major case in parse_g_word; the first
+            // decimal digit selects sub-case. Round-half-up so 0.45 reads as
+            // 4 — anything finer than .X is below the spec we ship.
+            const float gv = parse_float_token(s, i);
+            const int   gi = static_cast<int>(gv);
+            const float gf = gv - static_cast<float>(gi);
+            int frac = static_cast<int>(gf * 10.0f + 0.5f);
+            if (frac >= 10) frac = 9;
+            if (frac < 0)   frac = 0;
+            parse_g_word(gi, frac, parsed);
         } else if (word == 'M') {
             parsed.m_code = static_cast<long>(parse_float_token(s, i));
         } else if (word == 'F') {
@@ -1127,6 +1159,12 @@ bool Runtime::tick_channel(size_t channel) noexcept {
         state.tool_length_x_counts = static_cast<int32_t>(tos.length_x * 100.0f);
         state.tool_length_y_counts = static_cast<int32_t>(tos.length_y * 100.0f);
     }
+    // G43.4 / G43.5 enable TCP; G49.1 cancels. set_tcp_active here ensures
+    // operator API + interpreter modal flag stay coherent — the operator
+    // could have flipped TCP via the `tcp` CLI verb mid-program; G43.4 in
+    // the part program then re-asserts the same flag with no surprise.
+    if (parsed.tcp_cancel) (void)set_tcp_active(channel, false);
+    if (parsed.tcp_enable) (void)set_tcp_active(channel, true);
 
     if (parsed.home) {
         if (!execute_home(state, *this, channel, parsed)) {

--- a/cnc/interpreter.cpp
+++ b/cnc/interpreter.cpp
@@ -641,30 +641,52 @@ static int32_t tool_length_counts(const Runtime::ChannelState& state, char word)
     }
 }
 
-// Apply the rotation R(β, γ) to (vx, vy, vz). β = pitch about Y (B),
-// γ = yaw about Z (C). order picks composition: CB applies R_B then R_C
-// (R = R_C · R_B); BC applies R_C then R_B (R = R_B · R_C). Sign of cb
-// / sb / cc / sc is built in by the caller — passing negated angles
-// computes R^-1 (== R^T for orthogonal R), used by tail mode.
-static void rotate_bc(float vx, float vy, float vz,
-                      float cb, float sb, float cc, float sc,
-                      Runtime::TcpOrder order,
-                      float& ox, float& oy, float& oz) {
-    if (order == Runtime::TcpOrder::CB) {
-        const float xb =  vx * cb + vz * sb;
-        const float yb =  vy;
-        const float zb = -vx * sb + vz * cb;
-        ox = xb * cc - yb * sc;
-        oy = xb * sc + yb * cc;
-        oz = zb;
-    } else {
-        const float xc =  vx * cc - vy * sc;
-        const float yc =  vx * sc + vy * cc;
-        const float zc =  vz;
-        ox =  xc * cb + zc * sb;
-        oy =  yc;
-        oz = -xc * sb + zc * cb;
+// Single-axis rotations. Each operates in place on (x, y, z) given the
+// pre-computed cos/sin of the angle. Convention:
+//   R_A (about +X / roll  — A axis word):
+//     y' =  y * ca - z * sa,  z' =  y * sa + z * ca
+//   R_B (about +Y / pitch — B axis word):
+//     x' =  x * cb + z * sb,  z' = -x * sb + z * cb
+//   R_C (about +Z / yaw   — C axis word):
+//     x' =  x * cc - y * sc,  y' =  x * sc + y * cc
+static inline void rot_a(float& x, float& y, float& z, float ca, float sa) {
+    (void)x;
+    const float ny = y * ca - z * sa;
+    const float nz = y * sa + z * ca;
+    y = ny; z = nz;
+}
+static inline void rot_b(float& x, float& y, float& z, float cb, float sb) {
+    (void)y;
+    const float nx =  x * cb + z * sb;
+    const float nz = -x * sb + z * cb;
+    x = nx; z = nz;
+}
+static inline void rot_c(float& x, float& y, float& z, float cc, float sc) {
+    (void)z;
+    const float nx = x * cc - y * sc;
+    const float ny = x * sc + y * cc;
+    x = nx; y = ny;
+}
+
+// Apply the composed rotation R to (vx, vy, vz) and write to (ox, oy, oz).
+// Convention: token "XY" composes R = R_X · R_Y, i.e. apply Y FIRST then
+// X. So CB applies B first, then C — same as the previous behaviour.
+static void rotate_axes(float vx, float vy, float vz,
+                        float ca, float sa,
+                        float cb, float sb,
+                        float cc, float sc,
+                        Runtime::TcpOrder order,
+                        float& ox, float& oy, float& oz) {
+    float x = vx, y = vy, z = vz;
+    switch (order) {
+        case Runtime::TcpOrder::CB: rot_b(x, y, z, cb, sb); rot_c(x, y, z, cc, sc); break;
+        case Runtime::TcpOrder::BC: rot_c(x, y, z, cc, sc); rot_b(x, y, z, cb, sb); break;
+        case Runtime::TcpOrder::CA: rot_a(x, y, z, ca, sa); rot_c(x, y, z, cc, sc); break;
+        case Runtime::TcpOrder::AC: rot_c(x, y, z, cc, sc); rot_a(x, y, z, ca, sa); break;
+        case Runtime::TcpOrder::BA: rot_a(x, y, z, ca, sa); rot_b(x, y, z, cb, sb); break;
+        case Runtime::TcpOrder::AB: rot_b(x, y, z, cb, sb); rot_a(x, y, z, ca, sa); break;
     }
+    ox = x; oy = y; oz = z;
 }
 
 // 5-axis TCP target correction.
@@ -703,18 +725,23 @@ static void apply_tcp_correction(Runtime::ChannelState& state,
                                  size_t channel,
                                  int32_t targets[motion::MAX_AXES]) {
     if (!state.tcp_active) return;
-    uint8_t x_idx=0, y_idx=0, z_idx=0, b_idx=0, c_idx=0;
+    uint8_t x_idx=0, y_idx=0, z_idx=0, a_idx=0, b_idx=0, c_idx=0;
     const bool has_xy =
         runtime.resolve_axis_word(channel, 'X', x_idx) &&
         runtime.resolve_axis_word(channel, 'Y', y_idx);
     const bool has_z = runtime.resolve_axis_word(channel, 'Z', z_idx);
     if (!has_xy || !has_z) return;
+    const bool has_a = runtime.resolve_axis_word(channel, 'A', a_idx);
     const bool has_b = runtime.resolve_axis_word(channel, 'B', b_idx);
     const bool has_c = runtime.resolve_axis_word(channel, 'C', c_idx);
 
     // Convention: rotary axis counts at 100 cnt/degree → degrees/100 →
-    // radians. cos(0)=1, sin(0)=0, so a 3-axis machine with no B/C falls
-    // through with the rotation reducing to identity.
+    // radians. cos(0)=1, sin(0)=0, so any axis the machine doesn't have
+    // contributes identity to the composition.
+    const float alpha_rad = has_a
+        ? (static_cast<float>(targets[a_idx]) / 100.0f) *
+          kernel::util::math::kDegToRad
+        : 0.0f;
     const float beta_rad  = has_b
         ? (static_cast<float>(targets[b_idx]) / 100.0f) *
           kernel::util::math::kDegToRad
@@ -723,6 +750,7 @@ static void apply_tcp_correction(Runtime::ChannelState& state,
         ? (static_cast<float>(targets[c_idx]) / 100.0f) *
           kernel::util::math::kDegToRad
         : 0.0f;
+    const float ca = cos_approx(alpha_rad), sa = sin_approx(alpha_rad);
     const float cb = cos_approx(beta_rad),  sb = sin_approx(beta_rad);
     const float cc = cos_approx(gamma_rad), sc = sin_approx(gamma_rad);
 
@@ -736,7 +764,7 @@ static void apply_tcp_correction(Runtime::ChannelState& state,
         const float ly = static_cast<float>(state.tool_length_y_counts);
         const float lz = static_cast<float>(state.tool_length_counts);
         float xw, yw, zw;
-        rotate_bc(lx, ly, lz, cb, sb, cc, sc, runtime.tcp_order(), xw, yw, zw);
+        rotate_axes(lx, ly, lz, ca, sa, cb, sb, cc, sc, runtime.tcp_order(), xw, yw, zw);
         // Undo the G43-scalar Z addition that resolve_targets applied
         // via tool_length_counts() so we don't correct twice.
         // tool_length_x/y weren't applied (3-axis G43 path is Z-only)
@@ -756,7 +784,7 @@ static void apply_tcp_correction(Runtime::ChannelState& state,
     const float dy = static_cast<float>(targets[y_idx] - pivot_y);
     const float dz = static_cast<float>(targets[z_idx] - pivot_z);
     float rx, ry, rz;
-    rotate_bc(dx, dy, dz, cb, sb, cc, sc, runtime.tcp_order(), rx, ry, rz);
+    rotate_axes(dx, dy, dz, ca, sa, cb, sb, cc, sc, runtime.tcp_order(), rx, ry, rz);
     targets[x_idx] = pivot_x + static_cast<int32_t>(rx);
     targets[y_idx] = pivot_y + static_cast<int32_t>(ry);
     targets[z_idx] = pivot_z + static_cast<int32_t>(rz);

--- a/cnc/interpreter.cpp
+++ b/cnc/interpreter.cpp
@@ -984,7 +984,7 @@ static bool plan_arc(Runtime::ChannelState& state,
     return true;
 }
 
-static bool advance_arc(Runtime::ChannelState& state) {
+static bool advance_arc(Runtime::ChannelState& state, size_t channel) {
     auto& arc = state.arc;
     if (!arc.active || arc.total_segments == 0) return false;
     ++arc.current_segment;
@@ -1146,7 +1146,7 @@ bool Runtime::tick_channel(size_t channel) noexcept {
         for (size_t guard = 0; guard < motion::Axis::CHAIN_DEPTH * 2; ++guard) {
             if (!channel_settled(channel)) break;  // chain ring full
             if (!state.arc.active) break;          // arc completed mid-burst
-            if (!advance_arc(state)) {
+            if (!advance_arc(state, channel)) {
                 state.state = State::Fault;
                 return false;
             }

--- a/cnc/interpreter.cpp
+++ b/cnc/interpreter.cpp
@@ -8,6 +8,7 @@
 #include "../ethercat/master.hpp"
 #include "../ui/operator_api.hpp"
 #include "../miniOS.hpp"
+#include "../klog.hpp"
 #include "../util_math.hpp"
 
 namespace cnc::interp {
@@ -630,12 +631,13 @@ static int32_t tool_length_counts(const Runtime::ChannelState& state, char word)
     }
 }
 
-// Tool-tip → spindle-reference transform for 5-axis TCP. Composes a head-
-// kinematics R_C * R_B rotation of the tool vector and subtracts it from
-// the requested tool-tip target so the X/Y/Z axes drive the spindle to
-// the position that puts the tip at the requested point. Rotary
-// targets[B] / targets[C] are expected in axis counts; conversion to
-// radians uses the kernel's 100 cnt/degree convention. Linear length
+// Tool-tip → spindle-reference transform for 5-axis TCP. Composes a
+// head-kinematics rotation of the tool vector and subtracts it from the
+// requested tool-tip target so the X/Y/Z axes drive the spindle to the
+// position that puts the tip at the requested point.
+//
+// Rotary targets[B] / targets[C] are expected in axis counts; conversion
+// to radians uses the kernel's 100 cnt/degree convention. Linear length
 // components are in axis counts (already pre-scaled into
 // state.tool_length_*_counts at G43 time).
 //
@@ -644,7 +646,22 @@ static int32_t tool_length_counts(const Runtime::ChannelState& state, char word)
 // a typical mill head with a spindle pointing -Z when B = 0 and C = 0
 // and a positive length_z, the tool vector in the machine frame is
 // (0, 0, -length_z), so the spindle reference position equals
-// tool_tip - R_C * R_B * (length_x, length_y, length_z).
+// tool_tip - R · (length_x, length_y, length_z).
+//
+// Rotation composition is selectable via Runtime::tcp_order():
+//   CB (default) — R = R_C · R_B  (B applied first, then C; matches the
+//                  millturn TSV's C-then-B parent chain).
+//   BC           — R = R_B · R_C  (C applied first, then B; AC/BC heads
+//                  where B is the outer joint).
+//
+// Mode selectable via Runtime::tcp_mode():
+//   Head — rotaries carry the tool. The composition above runs unchanged.
+//   Tail — rotaries carry the workpiece. The relationship between the
+//          requested tool-tip (in workpiece coords) and the machine-frame
+//          target depends on the rotary pivot offset, which today is not
+//          captured in the kinematic_model TSV. Until that lands, Tail
+//          falls through to the Head path and emits a one-shot klog
+//          warning so the operator notices.
 static void apply_tcp_correction(Runtime::ChannelState& state,
                                  Runtime& runtime,
                                  size_t channel,
@@ -661,6 +678,20 @@ static void apply_tcp_correction(Runtime::ChannelState& state,
     if (!has_xy || !has_z) return;
     const bool has_b = runtime.resolve_axis_word(channel, 'B', b_idx);
     const bool has_c = runtime.resolve_axis_word(channel, 'C', c_idx);
+    if (runtime.tcp_mode() == Runtime::TcpMode::Tail) {
+        // One-shot warning so the operator sees the limitation in klog;
+        // motion still advances using the head path so a multi-axis
+        // toolpath at least retains the rotary correction's primary
+        // contribution. Pivot-offset support lands with the kinematic_
+        // model TSV extension (see CHANNELS.md "TCP" task).
+        static bool warned_once = false;
+        if (!warned_once) {
+            warned_once = true;
+            const char msg[] =
+                "[tcp] tail-kinematics not implemented; falling back to head\n";
+            kernel::klog::record(msg, sizeof(msg) - 1);
+        }
+    }
     // Convention: rotary axis counts at 100 cnt/degree → degrees/100 →
     // radians. cos(0)=1, sin(0)=0, so a 3-axis machine with no B/C falls
     // through with the tool vector unrotated and the correction reduces
@@ -676,19 +707,32 @@ static void apply_tcp_correction(Runtime::ChannelState& state,
         ? (static_cast<float>(targets[c_idx]) / 100.0f) *
           kernel::util::math::kDegToRad
         : 0.0f;
-    const float cb = cos_approx(beta_rad), sb = sin_approx(beta_rad);
+    const float cb = cos_approx(beta_rad),  sb = sin_approx(beta_rad);
     const float cc = cos_approx(gamma_rad), sc = sin_approx(gamma_rad);
     const float lx = static_cast<float>(state.tool_length_x_counts);
     const float ly = static_cast<float>(state.tool_length_y_counts);
     const float lz = static_cast<float>(state.tool_length_counts);
-    // R_B (pitch around Y): (x', y', z') = (x*cb + z*sb, y, -x*sb + z*cb)
-    const float xb =  lx * cb + lz * sb;
-    const float yb =  ly;
-    const float zb = -lx * sb + lz * cb;
-    // R_C (yaw around Z): (x', y', z') = (x*cc - y*sc, x*sc + y*cc, z)
-    const float xw = xb * cc - yb * sc;
-    const float yw = xb * sc + yb * cc;
-    const float zw = zb;
+
+    float xw, yw, zw;
+    if (runtime.tcp_order() == Runtime::TcpOrder::CB) {
+        // R = R_C · R_B applied to (lx, ly, lz):
+        //   step 1 — R_B (pitch around Y):
+        //   step 2 — R_C (yaw around Z) on the R_B output.
+        const float xb =  lx * cb + lz * sb;
+        const float yb =  ly;
+        const float zb = -lx * sb + lz * cb;
+        xw = xb * cc - yb * sc;
+        yw = xb * sc + yb * cc;
+        zw = zb;
+    } else {
+        // R = R_B · R_C — apply R_C first, then R_B.
+        const float xc =  lx * cc - ly * sc;
+        const float yc =  lx * sc + ly * cc;
+        const float zc =  lz;
+        xw =  xc * cb + zc * sb;
+        yw =  yc;
+        zw = -xc * sb + zc * cb;
+    }
     // Undo the G43-scalar Z addition that resolve_targets applied via
     // tool_length_counts() so we don't correct twice. tool_length_x/y
     // weren't applied (3-axis G43 path is Z-only) so no undo there.

--- a/cnc/interpreter.hpp
+++ b/cnc/interpreter.hpp
@@ -177,12 +177,31 @@ public:
     bool set_tcp_active(size_t channel, bool active) noexcept;
     bool tcp_active(size_t channel) const noexcept;
 
-    // Rotation order for the head-kinematics composition. CB = R_C·R_B (the
-    // mill-turn TSV's C-then-B parenting, the historical default). BC = R_B
-    // ·R_C, used on AC/BC heads where B is parented to base. Set globally;
-    // read per-tick by apply_tcp_correction. Tail-kinematics gets its own
-    // mode; rotation order still applies inside it.
-    enum class TcpOrder : uint8_t { CB = 0, BC = 1 };
+    // Rotation order for the TCP composition. Two-letter token names the
+    // axis pair and the order; in all cases, the SECOND letter's rotation
+    // is applied FIRST (matches the kinematic-chain convention where the
+    // outermost joint name comes first when reading the chain from base).
+    //
+    //   CB (default) — R = R_C · R_B  (B applied first, then C; matches
+    //                  the mill-turn TSV's C-then-B parent chain).
+    //   BC           — R = R_B · R_C  (C first, then B).
+    //   CA           — R = R_C · R_A  (A around X applied first, then C).
+    //   AC           — R = R_A · R_C
+    //   BA           — R = R_B · R_A
+    //   AB           — R = R_A · R_B
+    //
+    // R_A is roll about +X (A axis word), R_B pitch about +Y (B), R_C
+    // yaw about +Z (C). Set globally; read per-tick by apply_tcp_correction.
+    // Tail-kinematics gets its own mode; rotation order still applies
+    // inside it.
+    enum class TcpOrder : uint8_t {
+        CB = 0,
+        BC = 1,
+        CA = 2,
+        AC = 3,
+        BA = 4,
+        AB = 5,
+    };
     enum class TcpMode  : uint8_t { Head = 0, Tail = 1 };
     void      set_tcp_order(TcpOrder order) noexcept { tcp_order_ = order; }
     TcpOrder  tcp_order() const noexcept             { return tcp_order_; }

--- a/cnc/interpreter.hpp
+++ b/cnc/interpreter.hpp
@@ -173,6 +173,18 @@ public:
     bool set_tcp_active(size_t channel, bool active) noexcept;
     bool tcp_active(size_t channel) const noexcept;
 
+    // Rotation order for the head-kinematics composition. CB = R_C·R_B (the
+    // mill-turn TSV's C-then-B parenting, the historical default). BC = R_B
+    // ·R_C, used on AC/BC heads where B is parented to base. Set globally;
+    // read per-tick by apply_tcp_correction. Tail-kinematics gets its own
+    // mode; rotation order still applies inside it.
+    enum class TcpOrder : uint8_t { CB = 0, BC = 1 };
+    enum class TcpMode  : uint8_t { Head = 0, Tail = 1 };
+    void      set_tcp_order(TcpOrder order) noexcept { tcp_order_ = order; }
+    TcpOrder  tcp_order() const noexcept             { return tcp_order_; }
+    void      set_tcp_mode(TcpMode mode) noexcept    { tcp_mode_ = mode; }
+    TcpMode   tcp_mode() const noexcept              { return tcp_mode_; }
+
     // Mid-program restart. Reloads the selected program on `channel`, then
     // does a motion-free scan of lines 0..target_line-1, applying only modal
     // side effects (absolute/inch/plane/motion-mode, feed/spindle, active
@@ -205,6 +217,8 @@ private:
     uint64_t now_us() const noexcept;
 
     ChannelState channels_[programs::MAX_CHANNELS]{};
+    TcpOrder     tcp_order_ = TcpOrder::CB;
+    TcpMode      tcp_mode_  = TcpMode::Head;
 };
 
 extern Runtime g_runtime;

--- a/cnc/interpreter.hpp
+++ b/cnc/interpreter.hpp
@@ -188,6 +188,19 @@ public:
     TcpOrder  tcp_order() const noexcept             { return tcp_order_; }
     void      set_tcp_mode(TcpMode mode) noexcept    { tcp_mode_ = mode; }
     TcpMode   tcp_mode() const noexcept              { return tcp_mode_; }
+    // Tail-kinematics rotary pivot in machine-frame axis counts. The
+    // pivot is the (X,Y,Z) point about which the workpiece rotates when
+    // both rotaries are at zero. apply_tcp_correction in tail mode
+    // rotates the requested target around this pivot. Default (0,0,0)
+    // means "rotaries pivot at the workpiece origin" — fine for a
+    // calibrated G54 setup. Per-machine commissioning sets it via the
+    // CLI or setup snapshot.
+    void      set_tcp_pivot(int32_t x, int32_t y, int32_t z) noexcept {
+        tcp_pivot_x_ = x; tcp_pivot_y_ = y; tcp_pivot_z_ = z;
+    }
+    void      tcp_pivot(int32_t& x, int32_t& y, int32_t& z) const noexcept {
+        x = tcp_pivot_x_; y = tcp_pivot_y_; z = tcp_pivot_z_;
+    }
 
     // Mid-program restart. Reloads the selected program on `channel`, then
     // does a motion-free scan of lines 0..target_line-1, applying only modal
@@ -223,6 +236,9 @@ private:
     ChannelState channels_[programs::MAX_CHANNELS]{};
     TcpOrder     tcp_order_ = TcpOrder::CB;
     TcpMode      tcp_mode_  = TcpMode::Head;
+    int32_t      tcp_pivot_x_ = 0;
+    int32_t      tcp_pivot_y_ = 0;
+    int32_t      tcp_pivot_z_ = 0;
 };
 
 extern Runtime g_runtime;

--- a/cnc/interpreter.hpp
+++ b/cnc/interpreter.hpp
@@ -96,6 +96,10 @@ public:
         size_t active_work = 0;
         size_t active_tool = 0;
         size_t pending_tool = 0;
+        // M48 enables feed/spindle override sliders, M49 disables them
+        // (treats permille as fixed at 1000). Default true so a fresh
+        // program respects the operator's overrides until told otherwise.
+        bool override_active = true;
         bool tool_length_active = false;
         // Tool-Centre-Point (TCP) mode. When enabled with a non-zero
         // tool-length vector, the interpreter treats X/Y/Z axis words in

--- a/cnc/jobs.cpp
+++ b/cnc/jobs.cpp
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#include "jobs.hpp"
+
+#include "interpreter.hpp"
+#include "programs.hpp"
+#include "offsets.hpp"
+#include "../machine/pallet.hpp"
+#include "../util.hpp"
+#include "../miniOS.hpp"
+
+namespace cnc::jobs {
+
+Runtime g_runtime;
+
+namespace {
+
+// Same lightweight TSV parser the rest of the kernel uses. Lines start
+// with a record kind token followed by tab-separated key=value fields.
+const char* next_line(const char* p, const char* end, char* out, size_t out_size) {
+    size_t i = 0;
+    while (p < end && (*p == '\r' || *p == '\n')) ++p;
+    while (p < end && *p != '\r' && *p != '\n' && i + 1 < out_size) out[i++] = *p++;
+    out[i] = '\0';
+    while (p < end && *p != '\r' && *p != '\n') ++p;
+    while (p < end && (*p == '\r' || *p == '\n')) ++p;
+    return p;
+}
+
+const char* field_value(const char* line, const char* key, char* scratch, size_t scratch_size) {
+    if (!line || !key || !scratch || scratch_size == 0) return nullptr;
+    const char* p = line;
+    while (*p && *p != '\t') ++p;
+    while (*p == '\t') {
+        ++p;
+        const char* field = p;
+        while (*p && *p != '\t') ++p;
+        const char* eq = field;
+        while (eq < p && *eq != '=') ++eq;
+        if (eq >= p) continue;
+        const size_t key_len = static_cast<size_t>(eq - field);
+        if (kernel::util::kstrlen(key) == key_len &&
+            kernel::util::kmemcmp(field, key, key_len) == 0) {
+            const char* value = eq + 1;
+            const size_t value_len = static_cast<size_t>(p - value);
+            const size_t copy = value_len + 1 < scratch_size ? value_len : scratch_size - 1;
+            for (size_t i = 0; i < copy; ++i) scratch[i] = value[i];
+            scratch[copy] = '\0';
+            return scratch;
+        }
+    }
+    return nullptr;
+}
+
+long parse_long(const char* s, long fallback = 0) {
+    if (!s || !*s) return fallback;
+    bool neg = false;
+    if (*s == '-') { neg = true; ++s; }
+    long v = 0;
+    while (*s >= '0' && *s <= '9') { v = v * 10 + (*s - '0'); ++s; }
+    return neg ? -v : v;
+}
+
+void copy_string(char* dst, size_t cap, const char* src) {
+    if (!dst || cap == 0) return;
+    if (!src) { dst[0] = '\0'; return; }
+    kernel::util::k_snprintf(dst, cap, "%s", src);
+}
+
+}  // namespace
+
+bool Runtime::load_tsv(const char* buf, size_t len) noexcept {
+    if (!buf || len == 0) return false;
+    kernel::core::ScopedLock lock(lock_);
+    for (auto& j : jobs_) j = Job{};
+    job_count_ = 0;
+    active_    = SIZE_MAX;
+    state_     = SchedulerState::Idle;
+    const char* p = buf;
+    const char* end = buf + len;
+    char line[256];
+    while (p < end) {
+        p = next_line(p, end, line, sizeof(line));
+        if (line[0] == '\0' || line[0] == '#') continue;
+        char* rest = line;
+        while (*rest && *rest != '\t') ++rest;
+        if (*rest == '\t') *rest++ = '\0';
+        if (kernel::util::kstrcmp(line, "job") == 0) {
+            if (job_count_ >= MAX_JOBS) continue;
+            auto& j = jobs_[job_count_++];
+            j = Job{};
+            j.used = true;
+            char a[64], b[64], c[64], d[64], e[64], f[64];
+            copy_string(j.id,        sizeof(j.id),        field_value(rest, "id",      a, sizeof(a)));
+            copy_string(j.pallet_id, sizeof(j.pallet_id), field_value(rest, "pallet",  b, sizeof(b)));
+            const char* prog = field_value(rest, "program", c, sizeof(c));
+            if (prog) copy_string(j.program, sizeof(j.program), prog);
+            j.work_offset_index = static_cast<int>(parse_long(field_value(rest, "wcs",     d, sizeof(d)), -1));
+            j.repeat            = static_cast<uint32_t>(parse_long(field_value(rest, "repeat",   e, sizeof(e)), 1));
+            j.priority          = static_cast<uint8_t>(parse_long(field_value(rest, "priority", f, sizeof(f)), 100));
+        }
+    }
+    return true;
+}
+
+size_t Runtime::job_count() const noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    return job_count_;
+}
+
+const Job* Runtime::job(size_t idx) const noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (idx >= job_count_ || !jobs_[idx].used) return nullptr;
+    return &jobs_[idx];
+}
+
+bool Runtime::find_job(const char* id, size_t& idx_out) const noexcept {
+    if (!id) return false;
+    kernel::core::ScopedLock lock(lock_);
+    for (size_t i = 0; i < job_count_; ++i) {
+        if (jobs_[i].used && kernel::util::kstrcmp(jobs_[i].id, id) == 0) {
+            idx_out = i;
+            return true;
+        }
+    }
+    return false;
+}
+
+SchedulerState Runtime::state() const noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    return state_;
+}
+
+bool Runtime::start_scheduler() noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (state_ == SchedulerState::Stopped) return false;
+    state_ = SchedulerState::Running;
+    return true;
+}
+
+bool Runtime::pause_scheduler() noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (state_ != SchedulerState::Running) return false;
+    state_ = SchedulerState::Holding;
+    return true;
+}
+
+bool Runtime::resume_scheduler() noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (state_ != SchedulerState::Holding) return false;
+    state_ = SchedulerState::Running;
+    return true;
+}
+
+bool Runtime::stop_scheduler() noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    state_ = SchedulerState::Stopped;
+    return true;
+}
+
+bool Runtime::skip_current() noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (active_ >= job_count_) return false;
+    jobs_[active_].state = JobState::Skipped;
+    copy_message(active_, "skipped by operator");
+    active_ = SIZE_MAX;
+    return true;
+}
+
+bool Runtime::abort_current() noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (active_ >= job_count_) return false;
+    // Stop the interpreter on channel 0 so the program halts mid-flight.
+    // The underlying motion is left to settle naturally; callers wanting
+    // an instant stop should hit the operator E-stop.
+    (void)cnc::interp::g_runtime.stop(0);
+    jobs_[active_].state = JobState::Faulted;
+    copy_message(active_, "aborted by operator");
+    active_ = SIZE_MAX;
+    state_  = SchedulerState::Holding;
+    return true;
+}
+
+size_t Runtime::active_job() const noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    return active_;
+}
+
+size_t Runtime::enqueue(const Job& tmpl) noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (job_count_ >= MAX_JOBS) return SIZE_MAX;
+    const size_t idx = job_count_++;
+    jobs_[idx] = tmpl;
+    jobs_[idx].used = true;
+    if (jobs_[idx].state == JobState::Done ||
+        jobs_[idx].state == JobState::Skipped) {
+        // Operator probably wants the new job to actually run.
+        jobs_[idx].state = JobState::Pending;
+    }
+    return idx;
+}
+
+bool Runtime::remove(size_t idx) noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (idx >= job_count_ || !jobs_[idx].used) return false;
+    if (idx == active_) return false; // can't remove the running job
+    jobs_[idx] = Job{};
+    return true;
+}
+
+void Runtime::copy_message(size_t idx, const char* msg) noexcept {
+    if (idx >= job_count_) return;
+    if (!msg) { jobs_[idx].last_message[0] = '\0'; return; }
+    kernel::util::k_snprintf(jobs_[idx].last_message,
+                             sizeof(jobs_[idx].last_message), "%s", msg);
+}
+
+bool Runtime::start_active(size_t idx) noexcept {
+    if (idx >= job_count_) return false;
+    auto& j = jobs_[idx];
+    if (!j.used) return false;
+    // Resolve the pallet (optional but recommended).
+    size_t pallet_idx = SIZE_MAX;
+    if (j.pallet_id[0] != '\0' &&
+        !machine::pallet::g_service.find_pallet(j.pallet_id, pallet_idx)) {
+        copy_message(idx, "pallet not in roster");
+        j.state = JobState::Faulted;
+        return false;
+    }
+    // Apply WCS override (job > pallet > leave alone). G-code dispatch
+    // already handles G54..G59 modally; we just promote it now so the
+    // first move uses the right offset.
+    int wcs = j.work_offset_index;
+    if (wcs < 0 && pallet_idx != SIZE_MAX) {
+        const auto* pl = machine::pallet::g_service.pallet(pallet_idx);
+        if (pl) wcs = pl->work_offset_index;
+    }
+    if (wcs >= 0 && wcs < static_cast<int>(cnc::offsets::WORK_OFFSET_COUNT)) {
+        (void)cnc::offsets::g_service.select_work(static_cast<size_t>(wcs));
+    }
+    // Promote the pallet.
+    if (pallet_idx != SIZE_MAX) {
+        (void)machine::pallet::g_service.set_active_pallet(pallet_idx);
+        (void)machine::pallet::g_service.set_status(pallet_idx,
+            machine::pallet::PalletStatus::Cutting);
+    }
+    // Pick the program in the store and start the interpreter on ch0.
+    size_t prog_idx = 0;
+    if (!cnc::programs::g_store.find_by_name(j.program, prog_idx)) {
+        copy_message(idx, "program not in store");
+        j.state = JobState::Faulted;
+        if (pallet_idx != SIZE_MAX) {
+            (void)machine::pallet::g_service.set_status(pallet_idx,
+                machine::pallet::PalletStatus::Fault);
+        }
+        return false;
+    }
+    if (!cnc::programs::g_store.select(0, prog_idx) ||
+        !cnc::programs::g_store.open_selected(0) ||
+        !cnc::interp::g_runtime.start(0)) {
+        copy_message(idx, "interp start failed");
+        j.state = JobState::Faulted;
+        return false;
+    }
+    j.state = JobState::Running;
+    copy_message(idx, "running");
+    active_ = idx;
+    return true;
+}
+
+void Runtime::on_interp_complete() noexcept {
+    if (active_ >= job_count_) return;
+    auto& j = jobs_[active_];
+    ++j.completed;
+    // Bump the pallet's cycle counter too — the lights-out dashboard
+    // lives off this number.
+    size_t pallet_idx = 0;
+    const bool have_pallet =
+        j.pallet_id[0] != '\0' &&
+        machine::pallet::g_service.find_pallet(j.pallet_id, pallet_idx);
+    if (have_pallet) (void)machine::pallet::g_service.bump_cycles_completed(pallet_idx);
+
+    if (j.repeat == 0 || j.completed < j.repeat) {
+        // More to make from the same fixture — re-arm on the same channel.
+        // The program's swap macro (M310 etc.) may have moved the part out
+        // and reloaded; we just re-run the same .ngc.
+        size_t prog_idx = 0;
+        if (cnc::programs::g_store.find_by_name(j.program, prog_idx) &&
+            cnc::programs::g_store.select(0, prog_idx) &&
+            cnc::programs::g_store.open_selected(0) &&
+            cnc::interp::g_runtime.start(0)) {
+            copy_message(active_, "re-armed for next cycle");
+            return;
+        }
+        // Re-arm failed → fall through to the Done path so the scheduler
+        // picks something else next tick.
+        copy_message(active_, "re-arm failed; advancing");
+    }
+    j.state = JobState::Done;
+    if (have_pallet) {
+        (void)machine::pallet::g_service.set_status(pallet_idx,
+            machine::pallet::PalletStatus::Done);
+        (void)machine::pallet::g_service.clear_active_pallet();
+    }
+    active_ = SIZE_MAX;
+}
+
+void Runtime::on_interp_fault() noexcept {
+    if (active_ >= job_count_) return;
+    auto& j = jobs_[active_];
+    j.state = JobState::Faulted;
+    copy_message(active_, "interpreter fault");
+    size_t pallet_idx = 0;
+    if (j.pallet_id[0] != '\0' &&
+        machine::pallet::g_service.find_pallet(j.pallet_id, pallet_idx)) {
+        (void)machine::pallet::g_service.set_status(pallet_idx,
+            machine::pallet::PalletStatus::Fault);
+        (void)machine::pallet::g_service.clear_active_pallet();
+    }
+    active_ = SIZE_MAX;
+    state_  = SchedulerState::Holding;
+}
+
+void Runtime::tick() noexcept {
+    kernel::core::ScopedLock lock(lock_);
+
+    // First — if a job is active, watch its interpreter state.
+    if (active_ < job_count_) {
+        const auto snap = cnc::interp::g_runtime.snapshot(0);
+        if (snap.state == cnc::interp::State::Complete) {
+            on_interp_complete();
+        } else if (snap.state == cnc::interp::State::Fault) {
+            on_interp_fault();
+        }
+        // Every other state — Running / WaitingBarrier / WaitingMacro /
+        // Dwell — means we keep waiting. Returning here keeps the pallet
+        // marked Cutting and the job Running.
+        return;
+    }
+
+    // No job active — if we're allowed to pick, do so.
+    if (state_ != SchedulerState::Running) {
+        if (state_ == SchedulerState::Holding) {
+            // Holding finished its current job (active_ is clear); settle
+            // to Idle so the operator sees the queue is paused.
+            state_ = SchedulerState::Idle;
+        }
+        return;
+    }
+
+    // Find the highest-priority Pending job that's not blocked. Lower
+    // priority value runs first (matches POSIX nice convention).
+    size_t pick = SIZE_MAX;
+    uint8_t best_prio = 0xFF;
+    for (size_t i = 0; i < job_count_; ++i) {
+        const auto& j = jobs_[i];
+        if (!j.used || j.state != JobState::Pending) continue;
+        if (j.priority < best_prio) {
+            best_prio = j.priority;
+            pick = i;
+        }
+    }
+    if (pick == SIZE_MAX) {
+        // Drained — settle.
+        state_ = SchedulerState::Idle;
+        return;
+    }
+    if (!start_active(pick)) {
+        // Job already promoted to Faulted by start_active. Stay Running
+        // so the next tick picks the next-best Pending job.
+    }
+}
+
+void Runtime::thread_entry(void* /*arg*/) {
+    // Cooperative 250 ms tick — the scheduler is decision-making, not
+    // real-time. Slower than the macro runtime's 1 ms tick because
+    // pallet / program transitions happen per-second at most.
+    for (;;) {
+        g_runtime.tick();
+        auto* tm = kernel::g_platform ? kernel::g_platform->get_timer_ops() : nullptr;
+        if (tm) tm->wait_until_ns((tm->get_system_time_us() + 250'000ULL) * 1000ULL);
+    }
+}
+
+}  // namespace cnc::jobs

--- a/cnc/jobs.cpp
+++ b/cnc/jobs.cpp
@@ -82,22 +82,23 @@ bool Runtime::load_tsv(const char* buf, size_t len) noexcept {
     while (p < end) {
         p = next_line(p, end, line, sizeof(line));
         if (line[0] == '\0' || line[0] == '#') continue;
-        char* rest = line;
-        while (*rest && *rest != '\t') ++rest;
-        if (*rest == '\t') *rest++ = '\0';
-        if (kernel::util::kstrcmp(line, "job") == 0) {
+        // See machine/pallet.cpp for the rationale: field_value()
+        // walks past the first \t-delimited token internally, so we
+        // pass `line` (with the record kind still in place) to avoid
+        // double-skipping the first key=value pair.
+        if (kernel::util::kstrncmp(line, "job\t", 4) == 0) {
             if (job_count_ >= MAX_JOBS) continue;
             auto& j = jobs_[job_count_++];
             j = Job{};
             j.used = true;
             char a[64], b[64], c[64], d[64], e[64], f[64];
-            copy_string(j.id,        sizeof(j.id),        field_value(rest, "id",      a, sizeof(a)));
-            copy_string(j.pallet_id, sizeof(j.pallet_id), field_value(rest, "pallet",  b, sizeof(b)));
-            const char* prog = field_value(rest, "program", c, sizeof(c));
+            copy_string(j.id,        sizeof(j.id),        field_value(line, "id",      a, sizeof(a)));
+            copy_string(j.pallet_id, sizeof(j.pallet_id), field_value(line, "pallet",  b, sizeof(b)));
+            const char* prog = field_value(line, "program", c, sizeof(c));
             if (prog) copy_string(j.program, sizeof(j.program), prog);
-            j.work_offset_index = static_cast<int>(parse_long(field_value(rest, "wcs",     d, sizeof(d)), -1));
-            j.repeat            = static_cast<uint32_t>(parse_long(field_value(rest, "repeat",   e, sizeof(e)), 1));
-            j.priority          = static_cast<uint8_t>(parse_long(field_value(rest, "priority", f, sizeof(f)), 100));
+            j.work_offset_index = static_cast<int>(parse_long(field_value(line, "wcs",     d, sizeof(d)), -1));
+            j.repeat            = static_cast<uint32_t>(parse_long(field_value(line, "repeat",   e, sizeof(e)), 1));
+            j.priority          = static_cast<uint8_t>(parse_long(field_value(line, "priority", f, sizeof(f)), 100));
         }
     }
     return true;
@@ -255,8 +256,16 @@ bool Runtime::start_active(size_t idx) noexcept {
         }
         return false;
     }
-    if (!cnc::programs::g_store.select(0, prog_idx) ||
-        !cnc::programs::g_store.open_selected(0) ||
+    if (!cnc::programs::g_store.select(0, prog_idx)) {
+        copy_message(idx, "program select failed");
+        j.state = JobState::Faulted;
+        return false;
+    }
+    // load_selected resets interpreter line/block/text_offset and modal
+    // state; start() alone would skip the reset on the second-and-later
+    // job because ch.loaded is sticky from the previous run, leaving the
+    // resume cursor at EOF and the new program would Complete on tick 1.
+    if (!cnc::interp::g_runtime.load_selected(0) ||
         !cnc::interp::g_runtime.start(0)) {
         copy_message(idx, "interp start failed");
         j.state = JobState::Faulted;
@@ -283,11 +292,13 @@ void Runtime::on_interp_complete() noexcept {
     if (j.repeat == 0 || j.completed < j.repeat) {
         // More to make from the same fixture — re-arm on the same channel.
         // The program's swap macro (M310 etc.) may have moved the part out
-        // and reloaded; we just re-run the same .ngc.
+        // and reloaded; we just re-run the same .ngc. Must call
+        // load_selected explicitly to rewind the interpreter cursor;
+        // start() alone keeps text_offset at EOF since ch.loaded is true.
         size_t prog_idx = 0;
         if (cnc::programs::g_store.find_by_name(j.program, prog_idx) &&
             cnc::programs::g_store.select(0, prog_idx) &&
-            cnc::programs::g_store.open_selected(0) &&
+            cnc::interp::g_runtime.load_selected(0) &&
             cnc::interp::g_runtime.start(0)) {
             copy_message(active_, "re-armed for next cycle");
             return;

--- a/cnc/jobs.hpp
+++ b/cnc/jobs.hpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Lights-out CNC job scheduler. Walks a fixed-capacity job table,
+// picks the next Pending job in priority order, opens its program on
+// channel 0, starts the interpreter, and waits for Complete / Fault
+// before advancing. Pallet handoff (clamp release, robot pick/place,
+// re-clamp) is left to the program itself — typically the program's
+// last line is `M310` which is a TSV-defined macro that drives the
+// robot interlock signals and waits for ack. The scheduler just
+// promotes pallet status as jobs finish so the next run picks up the
+// fresh fixture.
+//
+// Designed to run in a low-priority cooperative loop; the interpreter
+// + motion threads do all the time-critical work. The scheduler just
+// makes per-second decisions.
+
+#pragma once
+
+#include "../core.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace cnc::jobs {
+
+constexpr size_t MAX_JOBS = 16;
+constexpr size_t MAX_NAME_LEN = 32;
+constexpr size_t MAX_PROGRAM_LEN = 64;
+
+enum class JobState : uint8_t {
+    Pending = 0,    // queued, awaiting scheduler pick-up
+    Running,        // interpreter started; awaiting Complete / Fault
+    Done,           // repeat count reached; pallet promoted to Done
+    Faulted,        // interpreter Fault'd; scheduler transitioned to Holding
+    Skipped,        // operator skipped manually; not retried
+};
+
+enum class SchedulerState : uint8_t {
+    Idle = 0,       // no work to do (or never started)
+    Running,        // actively picking + running
+    Holding,        // pause-after-current; finish then settle to Idle
+    Stopped,        // manual stop; current job runs to natural end
+};
+
+struct Job {
+    bool     used      = false;
+    char     id[MAX_NAME_LEN]{};        // "J001", "fixture_a_run"
+    char     pallet_id[MAX_NAME_LEN]{}; // pallet to mount before running
+    char     program[MAX_PROGRAM_LEN]{};
+    int      work_offset_index = -1;    // overrides pallet's WCS when ≥0
+    uint32_t repeat    = 1;
+    uint32_t completed = 0;
+    uint8_t  priority  = 100;           // lower = run sooner
+    JobState state     = JobState::Pending;
+    char     last_message[64]{};
+};
+
+class Runtime {
+public:
+    bool   load_tsv(const char* buf, size_t len) noexcept;
+    size_t job_count() const noexcept;
+    const Job* job(size_t idx) const noexcept;
+    bool   find_job(const char* id, size_t& idx_out) const noexcept;
+
+    SchedulerState state() const noexcept;
+    bool start_scheduler() noexcept;     // Idle -> Running (picks up where it left off)
+    bool pause_scheduler() noexcept;     // Running -> Holding (finishes current, then Idle)
+    bool resume_scheduler() noexcept;    // Holding -> Running
+    bool stop_scheduler() noexcept;      // -> Stopped (current keeps running)
+
+    bool skip_current() noexcept;        // marks active job Skipped, clears active
+    bool abort_current() noexcept;       // same but stops the interpreter immediately
+
+    // Add a job at runtime. Returns the slot's index, or SIZE_MAX on full
+    // queue. Used by `job_add` CLI verb and the persistence layer.
+    size_t enqueue(const Job& tmpl) noexcept;
+    bool   remove(size_t idx) noexcept;
+
+    size_t active_job() const noexcept;
+
+    // One-shot tick. The scheduler thread (created in kernel::boot::
+    // create_runtime_services) calls this from a low-priority cooperative
+    // loop. tick() is non-blocking — it polls interpreter state, advances
+    // pallet/job status when the interpreter completes or faults, and
+    // picks the next job when the channel is idle.
+    void tick() noexcept;
+
+    static void thread_entry(void* arg);
+
+private:
+    bool start_active(size_t idx) noexcept;        // private — caller holds lock_
+    void on_interp_complete() noexcept;            // private — caller holds lock_
+    void on_interp_fault() noexcept;               // private — caller holds lock_
+    void copy_message(size_t idx, const char* msg) noexcept;
+
+    Job             jobs_[MAX_JOBS]{};
+    size_t          job_count_ = 0;
+    size_t          active_    = SIZE_MAX;
+    SchedulerState  state_     = SchedulerState::Idle;
+    mutable kernel::core::Spinlock lock_;
+};
+
+extern Runtime g_runtime;
+
+}  // namespace cnc::jobs

--- a/devices/embedded_automation.S
+++ b/devices/embedded_automation.S
@@ -25,3 +25,9 @@ _binary_embedded_toolpods_tsv_end:
 _binary_embedded_pallets_tsv_start:
 	.incbin "devices/embedded_pallets.tsv"
 _binary_embedded_pallets_tsv_end:
+
+	.global _binary_embedded_jobs_tsv_start
+	.global _binary_embedded_jobs_tsv_end
+_binary_embedded_jobs_tsv_start:
+	.incbin "devices/embedded_jobs.tsv"
+_binary_embedded_jobs_tsv_end:

--- a/devices/embedded_automation.S
+++ b/devices/embedded_automation.S
@@ -19,3 +19,9 @@ _binary_embedded_ladder_tsv_end:
 _binary_embedded_toolpods_tsv_start:
 	.incbin "devices/embedded_toolpods.tsv"
 _binary_embedded_toolpods_tsv_end:
+
+	.global _binary_embedded_pallets_tsv_start
+	.global _binary_embedded_pallets_tsv_end
+_binary_embedded_pallets_tsv_start:
+	.incbin "devices/embedded_pallets.tsv"
+_binary_embedded_pallets_tsv_end:

--- a/devices/embedded_jobs.tsv
+++ b/devices/embedded_jobs.tsv
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Lights-out job queue. The scheduler thread (cnc::jobs::Runtime) walks
+# this in priority order and runs each job's program on channel 0
+# until repeat-count is reached or the job faults.
+#
+# Format:
+#   job	id=...	pallet=...	program=...	wcs=N	repeat=N	priority=N
+#
+# Notes:
+#   - `pallet` references an id from devices/embedded_pallets.tsv. The
+#     scheduler promotes the pallet to Cutting on start and to Done on
+#     completion.
+#   - `wcs` overrides the pallet's default WCS when ≥ 0; -1 means use
+#     the pallet's wcs (or the program's modal G54..G59 if neither is
+#     set).
+#   - `repeat=0` runs forever — the scheduler re-arms the same program
+#     on the same pallet after each Complete.
+#   - `priority`: lower runs sooner (POSIX nice convention). Default 100.
+
+job	id=J001	pallet=P01	program=demo_face.ngc	wcs=0	repeat=4	priority=10
+job	id=J002	pallet=P02	program=demo_pocket.ngc	wcs=1	repeat=4	priority=20

--- a/devices/embedded_macros.tsv
+++ b/devices/embedded_macros.tsv
@@ -219,3 +219,85 @@ step	type=pod_select	pod=upper_turret	value_type=int	value=3
 step	type=sphere_calibrate
 step	type=set	symbol=probe_stylus_ok	value_type=bool	value=1
 step	type=set	symbol=probe_cycle_done	value_type=bool	value=1
+
+# --- Lights-out interlock macros ---
+# These macros drive a pallet-swap / robot-load / robot-unload handshake
+# via signals. The signal symbols (pallet_*, robot_*, fixture_*) are
+# declared up top in this file; bind them to physical EtherCAT IO via
+# devices/embedded_signals.tsv if you have a real cell controller.
+#
+# Convention:
+#   M315  pallet_swap         — fully release current pallet, request a
+#                                robot pick/place, wait for the cell to
+#                                signal "swap done" before continuing.
+#   M316  robot_load_part     — clamp open, request robot deposit, wait
+#                                for part_loaded ack, clamp close.
+#   M317  robot_unload_part   — clamp open, request robot pick, wait for
+#                                part_clear ack.
+#   M318  fixture_clamp       — single-step clamp (fixture-specific).
+#   M319  lights_out_complete — signal end-of-batch to the cell so it
+#                                can flag empty-stock or call an operator.
+#
+# All steps use the signals registry; if a signal isn't bound to real
+# hardware the macros run as far as the wait-with-timeout and surface a
+# fault — that's the design (it forces the operator to wire the cell up
+# before lights-out runs unattended).
+
+symbol	name=pallet_release_cmd	type=bool	initial=0	writable=1
+symbol	name=pallet_clamp_cmd	type=bool	initial=1	writable=1
+symbol	name=pallet_clamped_fb	type=bool	initial=1	writable=1
+symbol	name=pallet_swap_request	type=bool	initial=0	writable=1
+symbol	name=pallet_swap_done	type=bool	initial=0	writable=1
+symbol	name=robot_load_request	type=bool	initial=0	writable=1
+symbol	name=robot_load_done	type=bool	initial=0	writable=1
+symbol	name=robot_unload_request	type=bool	initial=0	writable=1
+symbol	name=robot_unload_done	type=bool	initial=0	writable=1
+symbol	name=part_loaded_fb	type=bool	initial=0	writable=1
+symbol	name=part_clear_fb	type=bool	initial=1	writable=1
+symbol	name=lights_out_batch_done	type=bool	initial=0	writable=1
+
+macro	id=pallet_swap	title=Pallet Swap	mcode=315
+# Drop the in-cycle clamp, ask the cell controller to swap, wait for
+# its swap_done ack, re-clamp. Timeout is the wall-clock cap on a
+# robot move — adjust per cell. 60 s here so a slow robot pick still
+# fits without faulting.
+step	type=set	symbol=pallet_clamp_cmd	value_type=bool	value=0
+step	type=set	symbol=pallet_release_cmd	value_type=bool	value=1
+step	type=wait	symbol=pallet_clamped_fb	value_type=bool	compare=eq	value=0	timeout_ms=5000
+step	type=set	symbol=pallet_swap_done	value_type=bool	value=0
+step	type=set	symbol=pallet_swap_request	value_type=bool	value=1
+step	type=wait	symbol=pallet_swap_done	value_type=bool	compare=eq	value=1	timeout_ms=60000
+step	type=set	symbol=pallet_swap_request	value_type=bool	value=0
+step	type=set	symbol=pallet_release_cmd	value_type=bool	value=0
+step	type=set	symbol=pallet_clamp_cmd	value_type=bool	value=1
+step	type=wait	symbol=pallet_clamped_fb	value_type=bool	compare=eq	value=1	timeout_ms=5000
+
+macro	id=robot_load_part	title=Robot Load Part	mcode=316
+# Clamp opens, ask the robot to drop a part into the fixture, wait
+# for part_loaded_fb, then clamp closes. Smaller than M315 because
+# only the part moves — the pallet stays put.
+step	type=set	symbol=pallet_clamp_cmd	value_type=bool	value=0
+step	type=set	symbol=robot_load_done	value_type=bool	value=0
+step	type=set	symbol=robot_load_request	value_type=bool	value=1
+step	type=wait	symbol=part_loaded_fb	value_type=bool	compare=eq	value=1	timeout_ms=30000
+step	type=set	symbol=robot_load_request	value_type=bool	value=0
+step	type=set	symbol=robot_load_done	value_type=bool	value=1
+step	type=set	symbol=pallet_clamp_cmd	value_type=bool	value=1
+
+macro	id=robot_unload_part	title=Robot Unload Part	mcode=317
+step	type=set	symbol=pallet_clamp_cmd	value_type=bool	value=0
+step	type=set	symbol=robot_unload_done	value_type=bool	value=0
+step	type=set	symbol=robot_unload_request	value_type=bool	value=1
+step	type=wait	symbol=part_clear_fb	value_type=bool	compare=eq	value=1	timeout_ms=30000
+step	type=set	symbol=robot_unload_request	value_type=bool	value=0
+step	type=set	symbol=robot_unload_done	value_type=bool	value=1
+
+macro	id=fixture_clamp	title=Fixture Clamp	mcode=318
+step	type=set	symbol=pallet_clamp_cmd	value_type=bool	value=1
+step	type=wait	symbol=pallet_clamped_fb	value_type=bool	compare=eq	value=1	timeout_ms=5000
+
+macro	id=lights_out_complete	title=Lights-Out Batch Done	mcode=319
+# Final marker. The job scheduler (cnc::jobs::Runtime) advances
+# pallets through cycles_completed automatically; this macro is for
+# the operator-facing signal ("call me when the batch is done").
+step	type=set	symbol=lights_out_batch_done	value_type=bool	value=1

--- a/devices/embedded_pallets.tsv
+++ b/devices/embedded_pallets.tsv
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Pallet roster for lights-out CNC. Each row defines one platform on
+# the swap table. station=N is the physical station index a robot's
+# pick/place macro looks up; wcs=0..5 maps to G54..G59 so the swap
+# macro can flip the active work offset before re-arming the program.
+#
+# Format:
+#   pallet	id=...	fixture=...	program=...	station=N	wcs=N	target=N	status=...
+#
+# Notes:
+#   - Empty `program` leaves the pallet in Empty status (won't be picked
+#     by the scheduler). Setting a program promotes the default to Loaded.
+#   - target=0 means run forever (the scheduler keeps re-running the
+#     same program until status flips). target>0 caps total cycles for
+#     that pallet — useful when one fixture holds N parts.
+
+pallet	id=P01	fixture=vise_a	program=demo_face.ngc	station=0	wcs=0	target=4	status=loaded
+pallet	id=P02	fixture=vise_b	program=demo_pocket.ngc	station=1	wcs=1	target=4	status=loaded
+pallet	id=P03	fixture=plate	program=	station=2	wcs=2	target=0	status=empty
+pallet	id=P04	fixture=plate	program=	station=3	wcs=3	target=0	status=empty

--- a/devices/embedded_ui.tsv
+++ b/devices/embedded_ui.tsv
@@ -742,6 +742,7 @@ button	id=service_alarms	parent=service_root	x=300	y=710	w=240	h=120	text=ALARMS
 button	id=service_macros	parent=service_root	x=560	y=710	w=240	h=120	text=MACROS	bg=#5B21B6	color=#FFFFFF	scale=2	focus=340
 button	id=service_homing	parent=service_root	x=820	y=710	w=220	h=120	text=HOMING	bg=#0F766E	color=#FFFFFF	scale=2	focus=345
 button	id=service_network	parent=service_root	x=560	y=850	w=240	h=80	text=NETWORK	bg=#0E7490	color=#FFFFFF	scale=1	focus=349
+button	id=service_lights_out	parent=service_root	x=820	y=850	w=220	h=80	text=LIGHTS-OUT	bg=#7C2D12	color=#FFFFFF	scale=1	focus=350
 label	id=service_comp_title	parent=service_root	x=40	y=850	w=400	h=24	text=COMPENSATION	color=#64748B	bg=#111827	scale=1
 button	id=service_pec	parent=service_root	x=40	y=880	w=320	h=120	text=PITCH ERROR	bg=#1D4ED8	color=#FFFFFF	scale=2	focus=346
 button	id=service_geometry	parent=service_root	x=380	y=880	w=320	h=120	text=GEOMETRY	bg=#1D4ED8	color=#FFFFFF	scale=2	focus=347
@@ -766,6 +767,7 @@ action	widget=service_pec	event=click	target=goto:pec
 action	widget=service_geometry	event=click	target=goto:geometry
 action	widget=service_sphere	event=click	target=goto:sphere
 action	widget=service_network	event=click	target=goto:network
+action	widget=service_lights_out	event=click	target=goto:lights_out
 
 # --- tier 5 — live state panel ---
 # Surfaces look-ahead chain depth (per channel), the TCP modal
@@ -1672,4 +1674,85 @@ button	id=rc_cancel	parent=rc_root	x=540	y=940	w=480	h=300	text=CANCEL	bg=#B91C1
 
 action	widget=rc_confirm	event=click	target=restart:confirm
 action	widget=rc_cancel	event=click	target=restart:cancel
+include	page=bottom_nav
+
+# ============================================================
+# lights_out -- per-pallet status grid + job scheduler controls.
+# Reached from SERVICE > LIGHTS-OUT. Each pallet row shows id /
+# status / assigned program / cycles done. Scheduler state strip
+# at the top, action buttons at the bottom (RUN / PAUSE / RESUME
+# / SKIP / ABORT). All state pulled live via the bindings added
+# alongside cnc::jobs::Runtime — operator can leave this page up
+# overnight to monitor an unattended batch.
+# ============================================================
+page	id=lights_out	title=Lights-Out
+panel	id=lo_root	x=0	y=0	w=1080	h=1740	bg=#0A0F1A	border=#1F2937
+label	id=lo_title	parent=lo_root	x=40	y=30	w=1000	h=40	text=LIGHTS-OUT BATCH	color=#F8FAFC	bg=#0A0F1A	align=center	scale=2
+
+# --- scheduler strip ---
+panel	id=lo_sched_panel	parent=lo_root	x=20	y=110	w=1040	h=170	bg=#111827	border=#334155
+label	id=lo_sched_state_lbl	parent=lo_root	x=40	y=124	w=300	h=28	text=SCHEDULER	color=#94A3B8	bg=#111827	scale=2
+label	id=lo_sched_state	parent=lo_root	x=350	y=120	w=300	h=44	text=---	color=#7DD3FC	bg=#0F172A	border=#334155	bind=scheduler:state	align=center	scale=2
+label	id=lo_sched_jobs_lbl	parent=lo_root	x=680	y=124	w=160	h=28	text=JOBS	color=#94A3B8	bg=#111827	scale=2
+label	id=lo_sched_jobs	parent=lo_root	x=850	y=120	w=170	h=44	text=0	color=#86EFAC	bg=#0F172A	border=#334155	bind=scheduler:jobcount	align=center	scale=2
+label	id=lo_active_lbl	parent=lo_root	x=40	y=200	w=300	h=28	text=ACTIVE JOB	color=#94A3B8	bg=#111827	scale=2
+label	id=lo_active	parent=lo_root	x=350	y=196	w=670	h=44	text=(none)	color=#FCD34D	bg=#0F172A	border=#334155	bind=scheduler:active	align=center	scale=2
+
+# --- pallet grid ---
+panel	id=lo_pallet_panel	parent=lo_root	x=20	y=300	w=1040	h=620	bg=#111827	border=#334155
+label	id=lo_pallet_title	parent=lo_root	x=40	y=314	w=400	h=28	text=PALLETS	color=#94A3B8	bg=#111827	scale=2
+
+# Column headers
+label	id=lo_h_id	parent=lo_root	x=40	y=356	w=160	h=28	text=ID	color=#64748B	bg=#111827	scale=1
+label	id=lo_h_status	parent=lo_root	x=210	y=356	w=180	h=28	text=STATUS	color=#64748B	bg=#111827	scale=1
+label	id=lo_h_program	parent=lo_root	x=400	y=356	w=420	h=28	text=PROGRAM	color=#64748B	bg=#111827	scale=1
+label	id=lo_h_cycles	parent=lo_root	x=830	y=356	w=200	h=28	text=CYCLES DONE	color=#64748B	bg=#111827	scale=1
+
+# Row 0 — P01
+label	id=lo_p0_id	parent=lo_root	x=40	y=394	w=160	h=44	text=---	color=#7DD3FC	bg=#0F172A	border=#334155	bind=pallet:0:id	align=center	scale=2
+label	id=lo_p0_status	parent=lo_root	x=210	y=394	w=180	h=44	text=---	color=#86EFAC	bg=#0F172A	border=#334155	bind=pallet:0:status	align=center	scale=2
+label	id=lo_p0_program	parent=lo_root	x=400	y=394	w=420	h=44	text=---	color=#CBD5E1	bg=#0F172A	border=#475569	bind=pallet:0:program	align=center	scale=1
+label	id=lo_p0_cycles	parent=lo_root	x=830	y=394	w=200	h=44	text=0	color=#FCD34D	bg=#0F172A	border=#334155	bind=pallet:0:cycles	align=center	scale=2
+
+# Row 1 — P02
+label	id=lo_p1_id	parent=lo_root	x=40	y=448	w=160	h=44	text=---	color=#7DD3FC	bg=#0F172A	border=#334155	bind=pallet:1:id	align=center	scale=2
+label	id=lo_p1_status	parent=lo_root	x=210	y=448	w=180	h=44	text=---	color=#86EFAC	bg=#0F172A	border=#334155	bind=pallet:1:status	align=center	scale=2
+label	id=lo_p1_program	parent=lo_root	x=400	y=448	w=420	h=44	text=---	color=#CBD5E1	bg=#0F172A	border=#475569	bind=pallet:1:program	align=center	scale=1
+label	id=lo_p1_cycles	parent=lo_root	x=830	y=448	w=200	h=44	text=0	color=#FCD34D	bg=#0F172A	border=#334155	bind=pallet:1:cycles	align=center	scale=2
+
+# Row 2 — P03
+label	id=lo_p2_id	parent=lo_root	x=40	y=502	w=160	h=44	text=---	color=#7DD3FC	bg=#0F172A	border=#334155	bind=pallet:2:id	align=center	scale=2
+label	id=lo_p2_status	parent=lo_root	x=210	y=502	w=180	h=44	text=---	color=#86EFAC	bg=#0F172A	border=#334155	bind=pallet:2:status	align=center	scale=2
+label	id=lo_p2_program	parent=lo_root	x=400	y=502	w=420	h=44	text=---	color=#CBD5E1	bg=#0F172A	border=#475569	bind=pallet:2:program	align=center	scale=1
+label	id=lo_p2_cycles	parent=lo_root	x=830	y=502	w=200	h=44	text=0	color=#FCD34D	bg=#0F172A	border=#334155	bind=pallet:2:cycles	align=center	scale=2
+
+# Row 3 — P04
+label	id=lo_p3_id	parent=lo_root	x=40	y=556	w=160	h=44	text=---	color=#7DD3FC	bg=#0F172A	border=#334155	bind=pallet:3:id	align=center	scale=2
+label	id=lo_p3_status	parent=lo_root	x=210	y=556	w=180	h=44	text=---	color=#86EFAC	bg=#0F172A	border=#334155	bind=pallet:3:status	align=center	scale=2
+label	id=lo_p3_program	parent=lo_root	x=400	y=556	w=420	h=44	text=---	color=#CBD5E1	bg=#0F172A	border=#475569	bind=pallet:3:program	align=center	scale=1
+label	id=lo_p3_cycles	parent=lo_root	x=830	y=556	w=200	h=44	text=0	color=#FCD34D	bg=#0F172A	border=#334155	bind=pallet:3:cycles	align=center	scale=2
+
+# --- action buttons ---
+# Five row of large buttons. Click semantics route through the action
+# table; the operator API or a small CLI wrapper actually fires the
+# scheduler verbs. Until those wrappers land, the buttons display the
+# affordance (and the CLI verbs `job_run` / `job_pause` / etc. work).
+panel	id=lo_action_panel	parent=lo_root	x=20	y=940	w=1040	h=300	bg=#111827	border=#334155
+label	id=lo_action_title	parent=lo_root	x=40	y=954	w=400	h=28	text=SCHEDULER CONTROL	color=#94A3B8	bg=#111827	scale=2
+button	id=lo_run	parent=lo_root	x=40	y=1000	w=200	h=200	text=RUN	bg=#15803D	color=#FFFFFF	scale=3	focus=970
+button	id=lo_pause	parent=lo_root	x=250	y=1000	w=200	h=200	text=PAUSE	bg=#B45309	color=#FFFFFF	scale=3	focus=971
+button	id=lo_resume	parent=lo_root	x=460	y=1000	w=200	h=200	text=RESUME	bg=#1D4ED8	color=#FFFFFF	scale=3	focus=972
+button	id=lo_skip	parent=lo_root	x=670	y=1000	w=180	h=200	text=SKIP	bg=#5B21B6	color=#FFFFFF	scale=3	focus=973
+button	id=lo_abort	parent=lo_root	x=860	y=1000	w=180	h=200	text=ABORT	bg=#B91C1C	color=#FFFFFF	scale=3	focus=974
+
+# --- klog tail panel for the lights-out night-watch view ---
+panel	id=lo_klog_panel	parent=lo_root	x=20	y=1260	w=1040	h=420	bg=#111827	border=#334155
+label	id=lo_klog_title	parent=lo_root	x=40	y=1274	w=400	h=28	text=KLOG TAIL	color=#94A3B8	bg=#111827	scale=2
+label	id=lo_klog	parent=lo_root	x=40	y=1310	w=1000	h=360	text=---	color=#FCA5A5	bg=#0F172A	border=#475569	bind=klog:tail	align=left	scale=1
+
+action	widget=lo_run	event=click	target=jobs:run
+action	widget=lo_pause	event=click	target=jobs:pause
+action	widget=lo_resume	event=click	target=jobs:resume
+action	widget=lo_skip	event=click	target=jobs:skip
+action	widget=lo_abort	event=click	target=jobs:abort
 include	page=bottom_nav

--- a/devices/embedded_ui.tsv
+++ b/devices/embedded_ui.tsv
@@ -766,6 +766,26 @@ action	widget=service_pec	event=click	target=goto:pec
 action	widget=service_geometry	event=click	target=goto:geometry
 action	widget=service_sphere	event=click	target=goto:sphere
 action	widget=service_network	event=click	target=goto:network
+
+# --- tier 5 — live state panel ---
+# Surfaces look-ahead chain depth (per channel), the TCP modal
+# composite, and the most recent klog tail so the operator can see why
+# a fault tripped without dropping to CLI. The lookahead labels share
+# the channel-level minimum-depth convention from queue_depth — the
+# slowest-feeding axis caps the effective queue.
+panel	id=service_tier5_panel	parent=service_root	x=20	y=1290	w=1040	h=380	bg=#111827	border=#334155
+label	id=service_tier5_title	parent=service_root	x=40	y=1304	w=400	h=28	text=LIVE STATE	color=#94A3B8	bg=#111827	scale=2
+label	id=service_la_lbl0	parent=service_root	x=40	y=1346	w=200	h=32	text=LOOKAHEAD CH0	color=#94A3B8	bg=#111827	scale=1
+label	id=service_la_val0	parent=service_root	x=250	y=1342	w=140	h=40	text=0	color=#7DD3FC	bg=#0F172A	border=#334155	bind=lookahead:0	align=center	scale=2
+label	id=service_la_lbl1	parent=service_root	x=400	y=1346	w=200	h=32	text=LOOKAHEAD CH1	color=#94A3B8	bg=#111827	scale=1
+label	id=service_la_val1	parent=service_root	x=610	y=1342	w=140	h=40	text=0	color=#7DD3FC	bg=#0F172A	border=#334155	bind=lookahead:1	align=center	scale=2
+label	id=service_la_capl	parent=service_root	x=760	y=1346	w=120	h=32	text=MAX	color=#94A3B8	bg=#111827	scale=1
+label	id=service_la_cap	parent=service_root	x=890	y=1342	w=130	h=40	text=0	color=#A1A1AA	bg=#0F172A	border=#334155	bind=lookahead:max	align=center	scale=2
+label	id=service_tcp_lbl	parent=service_root	x=40	y=1396	w=200	h=32	text=TCP	color=#94A3B8	bg=#111827	scale=1
+label	id=service_tcp_status	parent=service_root	x=250	y=1392	w=770	h=40	text=TCP off	color=#86EFAC	bg=#0F172A	border=#334155	bind=tcp:status	align=center	scale=2
+label	id=service_klog_lbl	parent=service_root	x=40	y=1446	w=200	h=32	text=FAULT TAIL	color=#94A3B8	bg=#111827	scale=1
+label	id=service_klog_tail	parent=service_root	x=40	y=1480	w=980	h=170	text=---	color=#FCA5A5	bg=#0F172A	border=#475569	bind=klog:tail	align=left	scale=1
+
 include	page=bottom_nav
 
 # ============================================================

--- a/fs/vfs.cpp
+++ b/fs/vfs.cpp
@@ -51,6 +51,8 @@ extern const char _binary_kinematic_mx850_tsv_start[];
 extern const char _binary_kinematic_mx850_tsv_end[];
 extern const char _binary_embedded_toolpods_tsv_start[];
 extern const char _binary_embedded_toolpods_tsv_end[];
+extern const char _binary_embedded_pallets_tsv_start[];
+extern const char _binary_embedded_pallets_tsv_end[];
 extern const char _binary_demo_box_obj_start[];
 extern const char _binary_demo_box_obj_end[];
 extern const char _binary_demo_part_stl_start[];
@@ -107,6 +109,8 @@ void register_embedded_defaults() noexcept {
                       _binary_kinematic_mx850_tsv_start, _binary_kinematic_mx850_tsv_end);
     register_embedded("system/machine/embedded_toolpods.tsv",
                       _binary_embedded_toolpods_tsv_start, _binary_embedded_toolpods_tsv_end);
+    register_embedded("system/machine/embedded_pallets.tsv",
+                      _binary_embedded_pallets_tsv_start, _binary_embedded_pallets_tsv_end);
     register_embedded("system/machine/demo_box.obj",
                       _binary_demo_box_obj_start, _binary_demo_box_obj_end);
     register_embedded("system/machine/demo_part.stl",

--- a/fs/vfs.cpp
+++ b/fs/vfs.cpp
@@ -53,6 +53,8 @@ extern const char _binary_embedded_toolpods_tsv_start[];
 extern const char _binary_embedded_toolpods_tsv_end[];
 extern const char _binary_embedded_pallets_tsv_start[];
 extern const char _binary_embedded_pallets_tsv_end[];
+extern const char _binary_embedded_jobs_tsv_start[];
+extern const char _binary_embedded_jobs_tsv_end[];
 extern const char _binary_demo_box_obj_start[];
 extern const char _binary_demo_box_obj_end[];
 extern const char _binary_demo_part_stl_start[];
@@ -111,6 +113,8 @@ void register_embedded_defaults() noexcept {
                       _binary_embedded_toolpods_tsv_start, _binary_embedded_toolpods_tsv_end);
     register_embedded("system/machine/embedded_pallets.tsv",
                       _binary_embedded_pallets_tsv_start, _binary_embedded_pallets_tsv_end);
+    register_embedded("system/machine/embedded_jobs.tsv",
+                      _binary_embedded_jobs_tsv_start, _binary_embedded_jobs_tsv_end);
     register_embedded("system/machine/demo_box.obj",
                       _binary_demo_box_obj_start, _binary_demo_box_obj_end);
     register_embedded("system/machine/demo_part.stl",

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -23,6 +23,7 @@ namespace kernel { namespace core { void run_benchmark_test(); } }
 #include "automation/probe_runtime.hpp"
 #include "machine/toolpods.hpp"
 #include "machine/pallet.hpp"
+#include "cnc/jobs.hpp"
 #include "machine/machine_topology.hpp"
 #include "machine/runtime_placement.hpp"
 #include "machine/motion_wiring.hpp"
@@ -600,6 +601,12 @@ void load_runtime_tsvs() {
             (void)machine::pallet::g_service.load_tsv(pl_data, pl_len);
         }
     }
+    {
+        const char* jb_data = nullptr; size_t jb_len = 0;
+        if (kernel::vfs::lookup("system/machine/embedded_jobs.tsv", jb_data, jb_len) && jb_len > 0) {
+            (void)cnc::jobs::g_runtime.load_tsv(jb_data, jb_len);
+        }
+    }
     const uintptr_t signals_start = reinterpret_cast<uintptr_t>(&_binary_embedded_signals_tsv_start);
     const uintptr_t signals_end = reinterpret_cast<uintptr_t>(&_binary_embedded_signals_tsv_end);
     if (signals_end > signals_start) {
@@ -721,6 +728,10 @@ void create_runtime_services(CreateThreadFn create_thread) {
     (void)create_thread(&macros::Runtime::thread_entry, nullptr, 6, macro_core, "macro", false, 1000);
     (void)create_thread(&ladder::Runtime::thread_entry, nullptr, 7, ladder_core, "ladder", false, 1000);
     (void)create_thread(&probe::Runtime::thread_entry, nullptr, 6, probe_core, "probe", false, 1000);
+    // Job scheduler — low priority, decision-making only. Same core as
+    // the macro runtime (cooperative; no real-time requirements). The
+    // thread polls per-channel interpreter state every 250 ms.
+    (void)create_thread(&cnc::jobs::Runtime::thread_entry, nullptr, 5, macro_core, "jobs", false, 1000);
     if (num_nets > hmi_nic) {
         hmi::g_service.configure(hmi_nic);
         log_timestamped("hmi: eth0 service...");

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -22,6 +22,7 @@ namespace kernel { namespace core { void run_benchmark_test(); } }
 #include "automation/ladder_runtime.hpp"
 #include "automation/probe_runtime.hpp"
 #include "machine/toolpods.hpp"
+#include "machine/pallet.hpp"
 #include "machine/machine_topology.hpp"
 #include "machine/runtime_placement.hpp"
 #include "machine/motion_wiring.hpp"
@@ -591,6 +592,12 @@ void load_runtime_tsvs() {
         const char* tp_data = nullptr; size_t tp_len = 0;
         if (kernel::vfs::lookup("system/machine/embedded_toolpods.tsv", tp_data, tp_len) && tp_len > 0) {
             (void)machine::toolpods::g_service.load_tsv(tp_data, tp_len);
+        }
+    }
+    {
+        const char* pl_data = nullptr; size_t pl_len = 0;
+        if (kernel::vfs::lookup("system/machine/embedded_pallets.tsv", pl_data, pl_len) && pl_len > 0) {
+            (void)machine::pallet::g_service.load_tsv(pl_data, pl_len);
         }
     }
     const uintptr_t signals_start = reinterpret_cast<uintptr_t>(&_binary_embedded_signals_tsv_start);

--- a/machine/pallet.cpp
+++ b/machine/pallet.cpp
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#include "pallet.hpp"
+
+#include "util.hpp"
+
+namespace machine::pallet {
+
+Service g_service;
+
+namespace {
+
+// Mirrors the toolpods loader's helpers — keep them local rather than
+// pulling in another header. TSV format: lines start with a record kind
+// token, then tab-separated key=value fields.
+const char* next_line(const char* p, const char* end, char* out, size_t out_size) {
+    size_t i = 0;
+    while (p < end && (*p == '\r' || *p == '\n')) ++p;
+    while (p < end && *p != '\r' && *p != '\n' && i + 1 < out_size) out[i++] = *p++;
+    out[i] = '\0';
+    while (p < end && *p != '\r' && *p != '\n') ++p;
+    while (p < end && (*p == '\r' || *p == '\n')) ++p;
+    return p;
+}
+
+const char* field_value(const char* line, const char* key, char* scratch, size_t scratch_size) {
+    if (!line || !key || !scratch || scratch_size == 0) return nullptr;
+    const char* p = line;
+    while (*p && *p != '\t') ++p;
+    while (*p == '\t') {
+        ++p;
+        const char* field = p;
+        while (*p && *p != '\t') ++p;
+        const char* eq = field;
+        while (eq < p && *eq != '=') ++eq;
+        if (eq >= p) continue;
+        const size_t key_len = static_cast<size_t>(eq - field);
+        if (kernel::util::kstrlen(key) == key_len &&
+            kernel::util::kmemcmp(field, key, key_len) == 0) {
+            const char* value = eq + 1;
+            const size_t value_len = static_cast<size_t>(p - value);
+            const size_t copy = value_len + 1 < scratch_size ? value_len : scratch_size - 1;
+            for (size_t i = 0; i < copy; ++i) scratch[i] = value[i];
+            scratch[copy] = '\0';
+            return scratch;
+        }
+    }
+    return nullptr;
+}
+
+long parse_long(const char* s, long fallback = 0) {
+    if (!s || !*s) return fallback;
+    bool neg = false;
+    if (*s == '-') { neg = true; ++s; }
+    long v = 0;
+    while (*s >= '0' && *s <= '9') { v = v * 10 + (*s - '0'); ++s; }
+    return neg ? -v : v;
+}
+
+void copy_string(char* dst, size_t cap, const char* src) {
+    if (!dst || cap == 0) return;
+    if (!src) { dst[0] = '\0'; return; }
+    kernel::util::k_snprintf(dst, cap, "%s", src);
+}
+
+}  // namespace
+
+const char* Service::status_name(PalletStatus s) noexcept {
+    switch (s) {
+        case PalletStatus::Empty:   return "empty";
+        case PalletStatus::Loaded:  return "loaded";
+        case PalletStatus::Cutting: return "cutting";
+        case PalletStatus::Done:    return "done";
+        case PalletStatus::Fault:   return "fault";
+        case PalletStatus::Hold:    return "hold";
+    }
+    return "?";
+}
+
+bool Service::parse_status(const char* token, PalletStatus& out) noexcept {
+    if (!token) return false;
+    if (kernel::util::kstrcmp(token, "empty")   == 0) { out = PalletStatus::Empty;   return true; }
+    if (kernel::util::kstrcmp(token, "loaded")  == 0) { out = PalletStatus::Loaded;  return true; }
+    if (kernel::util::kstrcmp(token, "cutting") == 0) { out = PalletStatus::Cutting; return true; }
+    if (kernel::util::kstrcmp(token, "done")    == 0) { out = PalletStatus::Done;    return true; }
+    if (kernel::util::kstrcmp(token, "fault")   == 0) { out = PalletStatus::Fault;   return true; }
+    if (kernel::util::kstrcmp(token, "hold")    == 0) { out = PalletStatus::Hold;    return true; }
+    return false;
+}
+
+void Service::reset() noexcept {
+    for (auto& p : pallets_) p = Pallet{};
+    count_  = 0;
+    active_ = SIZE_MAX;
+}
+
+bool Service::load_tsv(const char* buf, size_t len) noexcept {
+    if (!buf || len == 0) return false;
+    kernel::core::ScopedLock lock(lock_);
+    reset();
+    const char* p = buf;
+    const char* end = buf + len;
+    char line[256];
+    while (p < end) {
+        p = next_line(p, end, line, sizeof(line));
+        if (line[0] == '\0' || line[0] == '#') continue;
+        char* rest = line;
+        while (*rest && *rest != '\t') ++rest;
+        if (*rest == '\t') *rest++ = '\0';
+        if (kernel::util::kstrcmp(line, "pallet") == 0) {
+            if (count_ >= MAX_PALLETS) continue;
+            auto& q = pallets_[count_++];
+            q = Pallet{};
+            q.used = true;
+            char a[64], b[64], c[64], d[64], e[64], f[64];
+            copy_string(q.id,         sizeof(q.id),         field_value(rest, "id",      a, sizeof(a)));
+            copy_string(q.fixture_id, sizeof(q.fixture_id), field_value(rest, "fixture", b, sizeof(b)));
+            const char* prog = field_value(rest, "program", c, sizeof(c));
+            if (prog) copy_string(q.assigned_program, sizeof(q.assigned_program), prog);
+            q.station_index     = static_cast<uint8_t>(
+                parse_long(field_value(rest, "station", d, sizeof(d)), static_cast<long>(count_ - 1)));
+            q.work_offset_index = static_cast<int>(
+                parse_long(field_value(rest, "wcs", e, sizeof(e)), -1));
+            q.target_cycles     = static_cast<uint32_t>(
+                parse_long(field_value(rest, "target", f, sizeof(f)), 0));
+            // Status is optional; Empty unless a program is wired up too,
+            // in which case Loaded is the more useful default.
+            const char* status_tok = field_value(rest, "status", a, sizeof(a));
+            PalletStatus s = q.assigned_program[0] != '\0' ? PalletStatus::Loaded
+                                                           : PalletStatus::Empty;
+            if (status_tok) (void)parse_status(status_tok, s);
+            q.status = s;
+        }
+    }
+    return count_ != 0;
+}
+
+size_t Service::pallet_count() const noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    return count_;
+}
+
+const Pallet* Service::pallet(size_t idx) const noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (idx >= count_ || !pallets_[idx].used) return nullptr;
+    return &pallets_[idx];
+}
+
+const Pallet* Service::pallet_by_id(const char* id) const noexcept {
+    if (!id) return nullptr;
+    kernel::core::ScopedLock lock(lock_);
+    for (size_t i = 0; i < count_; ++i) {
+        if (pallets_[i].used && kernel::util::kstrcmp(pallets_[i].id, id) == 0) {
+            return &pallets_[i];
+        }
+    }
+    return nullptr;
+}
+
+bool Service::find_pallet(const char* id, size_t& idx_out) const noexcept {
+    if (!id) return false;
+    kernel::core::ScopedLock lock(lock_);
+    for (size_t i = 0; i < count_; ++i) {
+        if (pallets_[i].used && kernel::util::kstrcmp(pallets_[i].id, id) == 0) {
+            idx_out = i;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Service::set_status(size_t idx, PalletStatus status) noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (idx >= count_ || !pallets_[idx].used) return false;
+    pallets_[idx].status = status;
+    return true;
+}
+
+bool Service::set_status(const char* id, PalletStatus status) noexcept {
+    size_t idx = 0;
+    if (!find_pallet(id, idx)) return false;
+    return set_status(idx, status);
+}
+
+bool Service::assign_program(size_t idx, const char* program, int work_offset_index) noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (idx >= count_ || !pallets_[idx].used) return false;
+    copy_string(pallets_[idx].assigned_program,
+                sizeof(pallets_[idx].assigned_program),
+                program ? program : "");
+    pallets_[idx].work_offset_index = work_offset_index;
+    return true;
+}
+
+bool Service::set_message(size_t idx, const char* msg) noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (idx >= count_ || !pallets_[idx].used) return false;
+    copy_string(pallets_[idx].last_message, sizeof(pallets_[idx].last_message),
+                msg ? msg : "");
+    return true;
+}
+
+bool Service::bump_cycles_completed(size_t idx) noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (idx >= count_ || !pallets_[idx].used) return false;
+    if (pallets_[idx].cycles_completed != UINT32_MAX) {
+        ++pallets_[idx].cycles_completed;
+    }
+    return true;
+}
+
+bool Service::set_target_cycles(size_t idx, uint32_t target) noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (idx >= count_ || !pallets_[idx].used) return false;
+    pallets_[idx].target_cycles = target;
+    return true;
+}
+
+size_t Service::active_pallet() const noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    return active_;
+}
+
+bool Service::set_active_pallet(size_t idx) noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (idx >= count_ || !pallets_[idx].used) return false;
+    active_ = idx;
+    return true;
+}
+
+bool Service::clear_active_pallet() noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    active_ = SIZE_MAX;
+    return true;
+}
+
+size_t Service::next_loaded_after(size_t start_idx) const noexcept {
+    kernel::core::ScopedLock lock(lock_);
+    if (count_ == 0) return SIZE_MAX;
+    const size_t begin = (start_idx >= count_) ? 0 : start_idx;
+    for (size_t off = 0; off < count_; ++off) {
+        const size_t i = (begin + off) % count_;
+        const auto& q = pallets_[i];
+        if (!q.used) continue;
+        if (q.status != PalletStatus::Loaded) continue;
+        // Pallet must have a program to be schedulable.
+        if (q.assigned_program[0] == '\0') continue;
+        return i;
+    }
+    return SIZE_MAX;
+}
+
+}  // namespace machine::pallet

--- a/machine/pallet.cpp
+++ b/machine/pallet.cpp
@@ -104,28 +104,30 @@ bool Service::load_tsv(const char* buf, size_t len) noexcept {
     while (p < end) {
         p = next_line(p, end, line, sizeof(line));
         if (line[0] == '\0' || line[0] == '#') continue;
-        char* rest = line;
-        while (*rest && *rest != '\t') ++rest;
-        if (*rest == '\t') *rest++ = '\0';
-        if (kernel::util::kstrcmp(line, "pallet") == 0) {
+        // Match the record-kind prefix non-destructively. field_value
+        // walks past the first \t-delimited token internally, so we
+        // pass `line` (with the record kind still in place) instead of
+        // a pre-stripped `rest` — otherwise the very first key=value
+        // pair (id=...) gets double-skipped and reads back as null.
+        if (kernel::util::kstrncmp(line, "pallet\t", 7) == 0) {
             if (count_ >= MAX_PALLETS) continue;
             auto& q = pallets_[count_++];
             q = Pallet{};
             q.used = true;
             char a[64], b[64], c[64], d[64], e[64], f[64];
-            copy_string(q.id,         sizeof(q.id),         field_value(rest, "id",      a, sizeof(a)));
-            copy_string(q.fixture_id, sizeof(q.fixture_id), field_value(rest, "fixture", b, sizeof(b)));
-            const char* prog = field_value(rest, "program", c, sizeof(c));
+            copy_string(q.id,         sizeof(q.id),         field_value(line, "id",      a, sizeof(a)));
+            copy_string(q.fixture_id, sizeof(q.fixture_id), field_value(line, "fixture", b, sizeof(b)));
+            const char* prog = field_value(line, "program", c, sizeof(c));
             if (prog) copy_string(q.assigned_program, sizeof(q.assigned_program), prog);
             q.station_index     = static_cast<uint8_t>(
-                parse_long(field_value(rest, "station", d, sizeof(d)), static_cast<long>(count_ - 1)));
+                parse_long(field_value(line, "station", d, sizeof(d)), static_cast<long>(count_ - 1)));
             q.work_offset_index = static_cast<int>(
-                parse_long(field_value(rest, "wcs", e, sizeof(e)), -1));
+                parse_long(field_value(line, "wcs", e, sizeof(e)), -1));
             q.target_cycles     = static_cast<uint32_t>(
-                parse_long(field_value(rest, "target", f, sizeof(f)), 0));
+                parse_long(field_value(line, "target", f, sizeof(f)), 0));
             // Status is optional; Empty unless a program is wired up too,
             // in which case Loaded is the more useful default.
-            const char* status_tok = field_value(rest, "status", a, sizeof(a));
+            const char* status_tok = field_value(line, "status", a, sizeof(a));
             PalletStatus s = q.assigned_program[0] != '\0' ? PalletStatus::Loaded
                                                            : PalletStatus::Empty;
             if (status_tok) (void)parse_status(status_tok, s);

--- a/machine/pallet.hpp
+++ b/machine/pallet.hpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Pallet table service for lights-out CNC. A pallet is a fixture-bearing
+// platform that gets swapped under the cutting envelope; each pallet
+// carries a different setup so the machine can run program A on pallet 1
+// then program B on pallet 2 without operator intervention.
+//
+// This module owns the pallet roster (TSV-loaded, like toolpods/macros)
+// and the per-pallet status. It does not drive a physical changer —
+// that's the robot's job, mediated by an M-code macro that handshakes
+// signals (request_swap, robot_clear, swap_done, ...). The macro reads
+// the active pallet through this service's API; the operator and the
+// HMI read its snapshot for status.
+//
+// Persisted via the existing setup snapshot (see cnc/setup.cpp); each
+// pallet's `status` and `assigned_program` survive a reboot so a
+// lights-out cycle interrupted at 02:00 picks up where it left off.
+
+#pragma once
+
+#include "../core.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace machine::pallet {
+
+constexpr size_t MAX_PALLETS = 8;
+constexpr size_t MAX_NAME_LEN = 32;
+constexpr size_t MAX_PROGRAM_LEN = 64;
+
+// Pallet lifecycle. The scheduler walks Loaded → Cutting → Done; the
+// operator (or a fault) can flip any pallet to Hold. Robot-mediated
+// swap only happens between Done (just finished) and Loaded (next part
+// arriving) — Cutting pallets are always under the spindle and must
+// not move.
+enum class PalletStatus : uint8_t {
+    Empty = 0,    // physical platform present, no fixture / part
+    Loaded,       // fixture + raw stock present, ready to cut
+    Cutting,      // currently under the spindle
+    Done,         // finished cycle, awaiting unload
+    Fault,        // last cycle tripped — operator inspection required
+    Hold,         // operator-paused; scheduler skips
+};
+
+struct Pallet {
+    bool     used = false;
+    char     id[MAX_NAME_LEN]{};            // "P01", "P02", ...
+    char     fixture_id[MAX_NAME_LEN]{};    // operator's fixture label
+    uint8_t  station_index = 0;             // physical position (0..MAX_PALLETS-1)
+    int      work_offset_index = -1;        // 0..5 → G54..G59; -1 = uncommitted
+    char     assigned_program[MAX_PROGRAM_LEN]{};  // .ngc file in the program store
+    uint32_t cycles_completed = 0;          // bumped on Done transitions
+    uint32_t target_cycles = 0;             // 0 = run forever
+    PalletStatus status = PalletStatus::Empty;
+    char     last_message[64]{};            // operator-visible note
+};
+
+class Service {
+public:
+    bool   load_tsv(const char* buf, size_t len) noexcept;
+    size_t pallet_count() const noexcept;
+    const Pallet* pallet(size_t idx) const noexcept;
+    const Pallet* pallet_by_id(const char* id) const noexcept;
+    bool   find_pallet(const char* id, size_t& idx_out) const noexcept;
+
+    // Mutations. All thread-safe via lock_.
+    bool set_status(size_t idx, PalletStatus status) noexcept;
+    bool set_status(const char* id, PalletStatus status) noexcept;
+    bool assign_program(size_t idx, const char* program, int work_offset_index) noexcept;
+    bool set_message(size_t idx, const char* msg) noexcept;
+    bool bump_cycles_completed(size_t idx) noexcept;
+    bool set_target_cycles(size_t idx, uint32_t target) noexcept;
+
+    // Active pallet — the one currently under the spindle. The scheduler
+    // sets this when transitioning a pallet to Cutting; the macro handshake
+    // (M310 pallet_swap) reads it to know which pallet to unload. Returns
+    // SIZE_MAX when no pallet is active.
+    size_t active_pallet() const noexcept;
+    bool   set_active_pallet(size_t idx) noexcept;
+    bool   clear_active_pallet() noexcept;
+
+    // Iterate pending work — first pallet in Loaded state past `start_idx`,
+    // honouring Hold (skipped) and Fault (skipped). Returns SIZE_MAX when
+    // no eligible pallet exists. The scheduler thread drives this to find
+    // the next job; the CLI / HMI use it for status.
+    size_t next_loaded_after(size_t start_idx) const noexcept;
+
+    static const char* status_name(PalletStatus s) noexcept;
+    static bool        parse_status(const char* token, PalletStatus& out) noexcept;
+
+private:
+    void reset() noexcept;
+
+    Pallet pallets_[MAX_PALLETS]{};
+    size_t count_ = 0;
+    size_t active_ = SIZE_MAX;
+    mutable kernel::core::Spinlock lock_;
+};
+
+extern Service g_service;
+
+}  // namespace machine::pallet

--- a/motion/CHANNELS.md
+++ b/motion/CHANNELS.md
@@ -158,3 +158,66 @@ What changes:
    on channel 2. Threading test: command spindle C1 to spin, engage
    Z2 at a known ratio, measure Z2 position vs C1 position over 1000
    cycles. Phase drift must be bounded.
+
+## Mill-turn G-code conventions (Phase B)
+
+Once the kernel has channels + barriers + gearing, programs need a
+small surface of M-codes to drive them. Fixed convention so a part
+program written against this kernel is portable across machines:
+
+### Sync barriers — M100 / M110 / M200 / M101..M109
+
+Same primitive (`Kernel::arrive_at_barrier`); ten distinct M-codes so
+a program can have multiple sync points without colliding tokens.
+
+- `M100 P<token> Q<channels-mask>` — generic rendezvous. Both `P`
+  and `Q` are optional. When `P` is omitted the token defaults to
+  `(mcode * 1000 + line) & 0xFFFF` so two `M100` lines on different
+  source lines automatically don't collide. When `Q` is omitted the
+  participants mask defaults to `0x3` (channel 0 + channel 1).
+- `M110`, `M200` — historical aliases of `M100`. Same shape.
+- `M101..M109` — named alternates. Useful when the source program
+  has a logical "after roughing", "after finishing", "after
+  part-off" sequence and the operator wants those distinct in
+  `barriers` / `sync_status` output.
+- Tolerance / stable_cycles / max_wait are kernel defaults today
+  (1 cnt / 3 cycles / 20 000 cycles ≈ 5 s at 250 µs). Per-program
+  tightening lands when a `G10.1 L<tol>` style verb is added.
+
+### Override enable/disable — M48 / M49
+
+- `M48` — feed and spindle override sliders are honoured for this
+  channel. Default at program start.
+- `M49` — overrides are pinned at 100 %. Used for synchronised cuts
+  (threading, rigid tap) where the operator's slider would otherwise
+  desynchronise the leader/follower phase relationship.
+
+The interpreter scales `feed_cps` and the spindle command by the
+channel's `feed_permille` / `spindle_permille` whenever
+`override_active` is true. M48/M49 toggle that flag.
+
+### Fault propagation across barriers (fault-fast-release)
+
+If any participant on an active barrier transitions to `Fault`
+(following error, drive trip, hard limit, ...) the arbiter
+immediately moves every other waiting participant to `Fault` in the
+same cycle. Without this fast-release, a peer fault left siblings
+stuck at `WaitingBarrier` for the full `max_wait_cycles` budget; the
+operator now sees the trip on every channel within one tick.
+
+### sync_status CLI
+
+`sync_status` is the one-shot mill-turn dashboard:
+
+```
+ch0(mill) state=running feed=100% rapid=100% spindle=100% jd=10
+  prog=part.ngc line=42 block=39 interp=running feed=600 spindle=2400 G43
+ch1(lathe) state=barrier feed=100% rapid=100% spindle=100% jd=10
+  prog=lathe.ngc line=78 block=66 interp=barrier feed=400 spindle=0
+  waiting on token=0x004f mask=0x03
+--- barriers ---
+[slot 0] token=0x004f parts=03 arrived=02 ...
+```
+
+Use this instead of stitching together `channels`, `barriers`, and
+`program_status` when triaging a stuck mill-turn program.

--- a/motion/motion.cpp
+++ b/motion/motion.cpp
@@ -1527,6 +1527,36 @@ void Kernel::run_sync_arbiter(uint64_t /*t_now*/) noexcept {
             }
         }
 
+        // Phase B fault-fast-release — if any participant has already
+        // transitioned to Fault, the others are now waiting on a peer that
+        // will never arrive (or never converge). Releasing the rest into
+        // Fault immediately keeps the operator from staring at "WaitingBarrier"
+        // for the full max_wait_cycles budget when they could have been
+        // alerted in the same cycle the trip happened. Same propagation
+        // shape as a timeout, just earlier.
+        bool any_participant_faulted = false;
+        for (size_t c = 0; c < channel_count_; ++c) {
+            const uint8_t bit = static_cast<uint8_t>(1u << c);
+            if ((b.participants_mask & bit) == 0) continue;
+            if (channels_[c].state == ChannelState::Fault) {
+                any_participant_faulted = true;
+                break;
+            }
+        }
+        if (any_participant_faulted) {
+            for (size_t c = 0; c < channel_count_; ++c) {
+                const uint8_t bit = static_cast<uint8_t>(1u << c);
+                if ((b.participants_mask & bit) == 0) continue;
+                if (channels_[c].state == ChannelState::WaitingBarrier) {
+                    channels_[c].state         = ChannelState::Fault;
+                    channels_[c].barrier_token = 0;
+                }
+            }
+            b.in_use = false;
+            stats_.faults.fetch_add(1, std::memory_order_relaxed);
+            continue;
+        }
+
         // Timeout check (applies whether or not everyone arrived — a
         // channel that never shows up counts against the budget).
         if (now_cycle - b.created_cycle > b.max_wait_cycles) {

--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -9,10 +9,12 @@
 #include "machine/toolpods.hpp"
 #include "cnc/programs.hpp"
 #include "cnc/mdi.hpp"
+#include "cnc/interpreter.hpp"
 #include "motion/motion.hpp"
 #include "ui/operator_api.hpp"
 #include "ui/ui.hpp"
 #include "miniOS.hpp"
+#include "klog.hpp"
 #include "util.hpp"
 
 #include <cstring>
@@ -539,6 +541,15 @@ enum class BindKind : uint16_t {
     ToolChangeCurrentPod, ToolChangeCurrentStation, ToolChangeCurrentLabel,
     ToolChangeTargetPod, ToolChangeTargetStation, ToolChangeTargetLabel,
     ToolChangeStep, ToolChangeTotalSteps,
+    // Tier 5 — operator-visible look-ahead / fault / TCP surfaces. Numeric
+    // bindings return the live count for sliders + labels; string bindings
+    // (KlogTail / TcpStatus) build a multi-line text the fault dialog can
+    // show inline. The motion / klog / interp APIs already exist —
+    // operator-side CLI verbs are queue_depth / tq / klog / tcp.
+    LookaheadDepthCh0, LookaheadDepthCh1,
+    LookaheadCapacity,            // motion::Axis::CHAIN_DEPTH (constant; useful for slider max=)
+    KlogTail,                     // last few klog lines, formatted via klog::tail
+    TcpStatus,                    // "off / head CB / ch0 on" composite string
 };
 
 BindKind parse_bind(const char* s) {
@@ -824,6 +835,11 @@ BindKind parse_bind(const char* s) {
     if (strcmp(s, "tc:target_lbl")  == 0) return BindKind::ToolChangeTargetLabel;
     if (strcmp(s, "tc:step")        == 0) return BindKind::ToolChangeStep;
     if (strcmp(s, "tc:total")       == 0) return BindKind::ToolChangeTotalSteps;
+    if (strcmp(s, "lookahead:0")    == 0) return BindKind::LookaheadDepthCh0;
+    if (strcmp(s, "lookahead:1")    == 0) return BindKind::LookaheadDepthCh1;
+    if (strcmp(s, "lookahead:max")  == 0) return BindKind::LookaheadCapacity;
+    if (strcmp(s, "klog:tail")      == 0) return BindKind::KlogTail;
+    if (strcmp(s, "tcp:status")     == 0) return BindKind::TcpStatus;
     return BindKind::None;
 }
 
@@ -1372,6 +1388,25 @@ int32_t bound_numeric_value(BindKind bind) {
             return static_cast<int32_t>(kernel::ui::operator_api::tool_change_snapshot().step);
         case BindKind::ToolChangeTotalSteps:
             return static_cast<int32_t>(kernel::ui::operator_api::tool_change_snapshot().total_steps);
+        case BindKind::LookaheadDepthCh0:
+        case BindKind::LookaheadDepthCh1: {
+            // Channel-level look-ahead depth = MIN over the channel's owned
+            // axes. The slowest-feeding axis caps the planner's effective
+            // queue; that's the number the operator wants on a label.
+            const size_t ci = (bind == BindKind::LookaheadDepthCh0) ? 0u : 1u;
+            if (ci >= motion::g_motion.channel_count()) return 0;
+            const auto& ch = motion::g_motion.channel(ci);
+            if (ch.axis_count == 0) return 0;
+            uint8_t min_depth = motion::Axis::CHAIN_DEPTH;
+            for (uint8_t k = 0; k < ch.axis_count; ++k) {
+                const uint8_t ai = ch.axis_indices[k];
+                const uint8_t d = motion::g_motion.axis_chain_count(ai);
+                if (d < min_depth) min_depth = d;
+            }
+            return static_cast<int32_t>(min_depth);
+        }
+        case BindKind::LookaheadCapacity:
+            return static_cast<int32_t>(motion::Axis::CHAIN_DEPTH);
         default: return 0;
     }
 }
@@ -2122,6 +2157,33 @@ void format_bind_value(BindKind bind, char* buf, size_t buf_size, const char* pr
         case BindKind::ToolChangeTotalSteps: {
             kernel::util::k_snprintf(buf, buf_size, "%s%ld", prefix ? prefix : "",
                                      static_cast<long>(bound_numeric_value(bind)));
+            return;
+        }
+        case BindKind::KlogTail: {
+            // Pull the most recent N bytes from the klog ring directly into
+            // the widget buffer. The fault dialog widget is sized at ~640
+            // chars / ~8 lines on a 1080x1920 canvas — plenty of room to
+            // surface the trip cause without dropping to CLI.
+            const size_t cap = (buf_size > 1) ? buf_size - 1 : 0;
+            const size_t n   = kernel::klog::tail(buf, cap);
+            buf[n < buf_size ? n : buf_size - 1] = '\0';
+            return;
+        }
+        case BindKind::TcpStatus: {
+            // "TCP off" / "TCP head CB ch0" — the simplest one-line state
+            // summary. Operator who needs more detail goes to CLI `tcp`.
+            using cnc::interp::Runtime;
+            const bool ch0 = cnc::interp::g_runtime.tcp_active(0);
+            const bool ch1 = cnc::interp::g_runtime.tcp_active(1);
+            if (!ch0 && !ch1) {
+                kernel::util::k_snprintf(buf, buf_size, "%sTCP off", prefix ? prefix : "");
+                return;
+            }
+            const char* mode  = (cnc::interp::g_runtime.tcp_mode()  == Runtime::TcpMode::Head) ? "head" : "tail";
+            const char* order = (cnc::interp::g_runtime.tcp_order() == Runtime::TcpOrder::CB)  ? "CB"   : "BC";
+            const char* who   = (ch0 && ch1) ? "both" : (ch0 ? "ch0" : "ch1");
+            kernel::util::k_snprintf(buf, buf_size, "%sTCP %s %s %s",
+                                     prefix ? prefix : "", mode, order, who);
             return;
         }
         default:

--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -553,7 +553,7 @@ enum class BindKind : uint16_t {
     KlogTail,                     // last few klog lines, formatted via klog::tail
     TcpStatus,                    // "off / head CB / ch0 on" composite string
     // Lights-out — per-pallet status text + scheduler dashboard. Pallet
-    // bindings index into machine::pallet::g_service by row 0..3.
+    // bindings index into ::machine::pallet::g_service by row 0..3.
     PalletId0, PalletId1, PalletId2, PalletId3,
     PalletStatus0, PalletStatus1, PalletStatus2, PalletStatus3,
     PalletProgram0, PalletProgram1, PalletProgram2, PalletProgram3,
@@ -1443,7 +1443,7 @@ int32_t bound_numeric_value(BindKind bind) {
         case BindKind::PalletCycles3: {
             const size_t row = static_cast<size_t>(static_cast<int>(bind) -
                                                    static_cast<int>(BindKind::PalletCycles0));
-            const auto* pl = machine::pallet::g_service.pallet(row);
+            const auto* pl = ::machine::pallet::g_service.pallet(row);
             return pl ? static_cast<int32_t>(pl->cycles_completed) : 0;
         }
         case BindKind::SchedulerJobCount:
@@ -2216,7 +2216,7 @@ void format_bind_value(BindKind bind, char* buf, size_t buf_size, const char* pr
         case BindKind::PalletId3: {
             const size_t row = static_cast<size_t>(static_cast<int>(bind) -
                                                    static_cast<int>(BindKind::PalletId0));
-            const auto* pl = machine::pallet::g_service.pallet(row);
+            const auto* pl = ::machine::pallet::g_service.pallet(row);
             const char* id = pl ? pl->id : "-";
             kernel::util::k_snprintf(buf, buf_size, "%s%s", prefix ? prefix : "", id);
             return;
@@ -2227,8 +2227,8 @@ void format_bind_value(BindKind bind, char* buf, size_t buf_size, const char* pr
         case BindKind::PalletStatus3: {
             const size_t row = static_cast<size_t>(static_cast<int>(bind) -
                                                    static_cast<int>(BindKind::PalletStatus0));
-            const auto* pl = machine::pallet::g_service.pallet(row);
-            const char* st = pl ? machine::pallet::Service::status_name(pl->status) : "-";
+            const auto* pl = ::machine::pallet::g_service.pallet(row);
+            const char* st = pl ? ::machine::pallet::Service::status_name(pl->status) : "-";
             kernel::util::k_snprintf(buf, buf_size, "%s%s", prefix ? prefix : "", st);
             return;
         }
@@ -2238,7 +2238,7 @@ void format_bind_value(BindKind bind, char* buf, size_t buf_size, const char* pr
         case BindKind::PalletProgram3: {
             const size_t row = static_cast<size_t>(static_cast<int>(bind) -
                                                    static_cast<int>(BindKind::PalletProgram0));
-            const auto* pl = machine::pallet::g_service.pallet(row);
+            const auto* pl = ::machine::pallet::g_service.pallet(row);
             const char* prog = (pl && pl->assigned_program[0]) ? pl->assigned_program : "-";
             kernel::util::k_snprintf(buf, buf_size, "%s%s", prefix ? prefix : "", prog);
             return;

--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -7,9 +7,11 @@
 #include "render/machine_model.hpp"
 #include "machine/machine_registry.hpp"
 #include "machine/toolpods.hpp"
+#include "machine/pallet.hpp"
 #include "cnc/programs.hpp"
 #include "cnc/mdi.hpp"
 #include "cnc/interpreter.hpp"
+#include "cnc/jobs.hpp"
 #include "motion/motion.hpp"
 #include "ui/operator_api.hpp"
 #include "ui/ui.hpp"
@@ -550,6 +552,15 @@ enum class BindKind : uint16_t {
     LookaheadCapacity,            // motion::Axis::CHAIN_DEPTH (constant; useful for slider max=)
     KlogTail,                     // last few klog lines, formatted via klog::tail
     TcpStatus,                    // "off / head CB / ch0 on" composite string
+    // Lights-out — per-pallet status text + scheduler dashboard. Pallet
+    // bindings index into machine::pallet::g_service by row 0..3.
+    PalletId0, PalletId1, PalletId2, PalletId3,
+    PalletStatus0, PalletStatus1, PalletStatus2, PalletStatus3,
+    PalletProgram0, PalletProgram1, PalletProgram2, PalletProgram3,
+    PalletCycles0, PalletCycles1, PalletCycles2, PalletCycles3,
+    SchedulerState,               // "idle / running / holding / stopped"
+    SchedulerActiveJob,           // active job's id or "(none)"
+    SchedulerJobCount,            // number of jobs in the queue
 };
 
 BindKind parse_bind(const char* s) {
@@ -840,6 +851,25 @@ BindKind parse_bind(const char* s) {
     if (strcmp(s, "lookahead:max")  == 0) return BindKind::LookaheadCapacity;
     if (strcmp(s, "klog:tail")      == 0) return BindKind::KlogTail;
     if (strcmp(s, "tcp:status")     == 0) return BindKind::TcpStatus;
+    if (strcmp(s, "pallet:0:id")        == 0) return BindKind::PalletId0;
+    if (strcmp(s, "pallet:1:id")        == 0) return BindKind::PalletId1;
+    if (strcmp(s, "pallet:2:id")        == 0) return BindKind::PalletId2;
+    if (strcmp(s, "pallet:3:id")        == 0) return BindKind::PalletId3;
+    if (strcmp(s, "pallet:0:status")    == 0) return BindKind::PalletStatus0;
+    if (strcmp(s, "pallet:1:status")    == 0) return BindKind::PalletStatus1;
+    if (strcmp(s, "pallet:2:status")    == 0) return BindKind::PalletStatus2;
+    if (strcmp(s, "pallet:3:status")    == 0) return BindKind::PalletStatus3;
+    if (strcmp(s, "pallet:0:program")   == 0) return BindKind::PalletProgram0;
+    if (strcmp(s, "pallet:1:program")   == 0) return BindKind::PalletProgram1;
+    if (strcmp(s, "pallet:2:program")   == 0) return BindKind::PalletProgram2;
+    if (strcmp(s, "pallet:3:program")   == 0) return BindKind::PalletProgram3;
+    if (strcmp(s, "pallet:0:cycles")    == 0) return BindKind::PalletCycles0;
+    if (strcmp(s, "pallet:1:cycles")    == 0) return BindKind::PalletCycles1;
+    if (strcmp(s, "pallet:2:cycles")    == 0) return BindKind::PalletCycles2;
+    if (strcmp(s, "pallet:3:cycles")    == 0) return BindKind::PalletCycles3;
+    if (strcmp(s, "scheduler:state")    == 0) return BindKind::SchedulerState;
+    if (strcmp(s, "scheduler:active")   == 0) return BindKind::SchedulerActiveJob;
+    if (strcmp(s, "scheduler:jobcount") == 0) return BindKind::SchedulerJobCount;
     return BindKind::None;
 }
 
@@ -1407,6 +1437,17 @@ int32_t bound_numeric_value(BindKind bind) {
         }
         case BindKind::LookaheadCapacity:
             return static_cast<int32_t>(motion::Axis::CHAIN_DEPTH);
+        case BindKind::PalletCycles0:
+        case BindKind::PalletCycles1:
+        case BindKind::PalletCycles2:
+        case BindKind::PalletCycles3: {
+            const size_t row = static_cast<size_t>(static_cast<int>(bind) -
+                                                   static_cast<int>(BindKind::PalletCycles0));
+            const auto* pl = machine::pallet::g_service.pallet(row);
+            return pl ? static_cast<int32_t>(pl->cycles_completed) : 0;
+        }
+        case BindKind::SchedulerJobCount:
+            return static_cast<int32_t>(cnc::jobs::g_runtime.job_count());
         default: return 0;
     }
 }
@@ -2169,6 +2210,58 @@ void format_bind_value(BindKind bind, char* buf, size_t buf_size, const char* pr
             buf[n < buf_size ? n : buf_size - 1] = '\0';
             return;
         }
+        case BindKind::PalletId0:
+        case BindKind::PalletId1:
+        case BindKind::PalletId2:
+        case BindKind::PalletId3: {
+            const size_t row = static_cast<size_t>(static_cast<int>(bind) -
+                                                   static_cast<int>(BindKind::PalletId0));
+            const auto* pl = machine::pallet::g_service.pallet(row);
+            const char* id = pl ? pl->id : "-";
+            kernel::util::k_snprintf(buf, buf_size, "%s%s", prefix ? prefix : "", id);
+            return;
+        }
+        case BindKind::PalletStatus0:
+        case BindKind::PalletStatus1:
+        case BindKind::PalletStatus2:
+        case BindKind::PalletStatus3: {
+            const size_t row = static_cast<size_t>(static_cast<int>(bind) -
+                                                   static_cast<int>(BindKind::PalletStatus0));
+            const auto* pl = machine::pallet::g_service.pallet(row);
+            const char* st = pl ? machine::pallet::Service::status_name(pl->status) : "-";
+            kernel::util::k_snprintf(buf, buf_size, "%s%s", prefix ? prefix : "", st);
+            return;
+        }
+        case BindKind::PalletProgram0:
+        case BindKind::PalletProgram1:
+        case BindKind::PalletProgram2:
+        case BindKind::PalletProgram3: {
+            const size_t row = static_cast<size_t>(static_cast<int>(bind) -
+                                                   static_cast<int>(BindKind::PalletProgram0));
+            const auto* pl = machine::pallet::g_service.pallet(row);
+            const char* prog = (pl && pl->assigned_program[0]) ? pl->assigned_program : "-";
+            kernel::util::k_snprintf(buf, buf_size, "%s%s", prefix ? prefix : "", prog);
+            return;
+        }
+        case BindKind::SchedulerState: {
+            const auto s = cnc::jobs::g_runtime.state();
+            const char* name = "?";
+            switch (s) {
+                case cnc::jobs::SchedulerState::Idle:    name = "idle";    break;
+                case cnc::jobs::SchedulerState::Running: name = "running"; break;
+                case cnc::jobs::SchedulerState::Holding: name = "holding"; break;
+                case cnc::jobs::SchedulerState::Stopped: name = "stopped"; break;
+            }
+            kernel::util::k_snprintf(buf, buf_size, "%s%s", prefix ? prefix : "", name);
+            return;
+        }
+        case BindKind::SchedulerActiveJob: {
+            const size_t idx = cnc::jobs::g_runtime.active_job();
+            const auto* j = (idx == SIZE_MAX) ? nullptr : cnc::jobs::g_runtime.job(idx);
+            const char* id = j ? j->id : "(none)";
+            kernel::util::k_snprintf(buf, buf_size, "%s%s", prefix ? prefix : "", id);
+            return;
+        }
         case BindKind::TcpStatus: {
             // "TCP off" / "TCP head CB ch0" — the simplest one-line state
             // summary. Operator who needs more detail goes to CLI `tcp`.
@@ -2542,6 +2635,20 @@ void run_action_target(const char* target) {
         const char* command = target + 6;
         if (strcmp(command, "save") == 0) save_setup();
         else if (strcmp(command, "load") == 0) load_setup();
+        return;
+    }
+    // Lights-out scheduler controls — same verbs the CLI exposes via
+    // job_run / job_pause / job_resume / job_skip / job_abort. Routed
+    // directly to the runtime since the operator_api wrapper layer
+    // doesn't add anything for these (the runtime is itself the
+    // ground-truth state).
+    if (strncmp(target, "jobs:", 5) == 0) {
+        const char* command = target + 5;
+        if      (strcmp(command, "run")    == 0) (void)cnc::jobs::g_runtime.start_scheduler();
+        else if (strcmp(command, "pause")  == 0) (void)cnc::jobs::g_runtime.pause_scheduler();
+        else if (strcmp(command, "resume") == 0) (void)cnc::jobs::g_runtime.resume_scheduler();
+        else if (strcmp(command, "skip")   == 0) (void)cnc::jobs::g_runtime.skip_current();
+        else if (strcmp(command, "abort")  == 0) (void)cnc::jobs::g_runtime.abort_current();
         return;
     }
     if (strncmp(target, "offset:work:", 12) == 0) {

--- a/ui/ui_builder_tsv.hpp
+++ b/ui/ui_builder_tsv.hpp
@@ -59,25 +59,10 @@ class Widget;
 
 namespace ui_builder {
 
-// Sized to fit all currently-shipped pages (~280 widgets when the
-// parser ran with the original 256 cap; line 472 of embedded_ui.tsv was
-// where it tripped). The PR adding the lights-out page + the service-
-// page "LIVE STATE" panel pushed it past 256, but that was masking
-// pre-existing growth too — the entire TSV has ~950 widget directives,
-// and incremental page additions had been silently losing the tail of
-// the file for several commits. 1024 covers the present load with
-// headroom for another 50% growth before another bump. Each WidgetNode
-// is ~660 B (WidgetSpec dominates with six MAX_FIELD_LEN char arrays),
-// so 1024 entries cost ~680 KiB — affordable in the 128 MB RAM
-// allocation but worth keeping an eye on if the field-len ever grows.
-constexpr uint32_t MAX_WIDGETS = 1024;
+constexpr uint32_t MAX_WIDGETS = 256;
 constexpr uint32_t MAX_PAGES = 32;
-// Same headroom rationale as MAX_WIDGETS — embedded_ui.tsv has ~170
-// `action` directives today. 256 caps fit historical content; the new
-// lights-out page added five more action targets and more headroom is
-// needed for future operator-button additions.
-constexpr uint32_t MAX_ACTIONS = 384;
-constexpr uint32_t MAX_CHILD_LINKS = 1024;
+constexpr uint32_t MAX_ACTIONS = 128;
+constexpr uint32_t MAX_CHILD_LINKS = 256;
 constexpr uint32_t MAX_FIELD_LEN = 96;
 
 // Widget types

--- a/ui/ui_builder_tsv.hpp
+++ b/ui/ui_builder_tsv.hpp
@@ -59,10 +59,25 @@ class Widget;
 
 namespace ui_builder {
 
-constexpr uint32_t MAX_WIDGETS = 256;
+// Sized to fit all currently-shipped pages (~280 widgets when the
+// parser ran with the original 256 cap; line 472 of embedded_ui.tsv was
+// where it tripped). The PR adding the lights-out page + the service-
+// page "LIVE STATE" panel pushed it past 256, but that was masking
+// pre-existing growth too — the entire TSV has ~950 widget directives,
+// and incremental page additions had been silently losing the tail of
+// the file for several commits. 1024 covers the present load with
+// headroom for another 50% growth before another bump. Each WidgetNode
+// is ~660 B (WidgetSpec dominates with six MAX_FIELD_LEN char arrays),
+// so 1024 entries cost ~680 KiB — affordable in the 128 MB RAM
+// allocation but worth keeping an eye on if the field-len ever grows.
+constexpr uint32_t MAX_WIDGETS = 1024;
 constexpr uint32_t MAX_PAGES = 32;
-constexpr uint32_t MAX_ACTIONS = 128;
-constexpr uint32_t MAX_CHILD_LINKS = 256;
+// Same headroom rationale as MAX_WIDGETS — embedded_ui.tsv has ~170
+// `action` directives today. 256 caps fit historical content; the new
+// lights-out page added five more action targets and more headroom is
+// needed for future operator-button additions.
+constexpr uint32_t MAX_ACTIONS = 384;
+constexpr uint32_t MAX_CHILD_LINKS = 1024;
 constexpr uint32_t MAX_FIELD_LEN = 96;
 
 // Widget types


### PR DESCRIPTION
## Summary

Closes the remaining deferred items on the original list and adds the lights-out automation surface (pallet service, job scheduler, robot interlock macros, HMI page).

### Deferred items (A-series)
- **A4** — `G43.4` / `G49.1` decimal G-code dispatch into the existing `tcp` operator API (`ededeee`).
- **A5** — TCP rotation-order knob (CB / BC) and tail-mode placeholder (`424ece0`). Tail falls back to head with a one-shot klog warning until pivot-offset support lands in the kinematic TSV.
- **A6** — Five new HMI bindings (`lookahead:0/1/max`, `tcp:status`, `klog:tail`) wired into a new "LIVE STATE" panel on the service page (`327cef3`).

### Phase B — mill-turn sync
- `6de2242` — wires the dormant `ChannelOverrides` through feed/spindle, adds `M48`/`M49` modal toggle, `M101..M109` named sync alternates, fault-fast-release in the barrier arbiter, a `sync_status` CLI dashboard, and a new "Mill-turn G-code conventions" section in `motion/CHANNELS.md`.

### Phase C — lights-out automation
- **C1** `f85b3eb` — `machine::pallet::Service` (TSV-loaded roster, status state machine, active-pallet pointer, `next_loaded_after`) + `pallets` / `pallet_status` / `pallet_assign` CLI verbs. Sample roster in `devices/embedded_pallets.tsv`.
- **C2** `bddf954` — `cnc::jobs::Runtime` scheduler thread (priority-ordered job queue, watches interpreter on ch0, advances pallet status on Complete, holds queue on Fault) + `jobs` / `job_run` / `job_pause` / `job_resume` / `job_skip` / `job_abort` CLI verbs. Sample queue in `devices/embedded_jobs.tsv`.
- **C3** `375e40b` — pure TSV: `M315` pallet_swap, `M316` robot_load_part, `M317` robot_unload_part, `M318` fixture_clamp, `M319` lights_out_complete + the symbols they handshake on.
- **C4** `3664591` — lights-out HMI page (scheduler strip, 4-row pallet grid, RUN/PAUSE/RESUME/SKIP/ABORT buttons, klog tail panel).

### Subtests
- `83783ec` — `test tcp` / `test pallet` / `test jobs` added to the `test all` set; structural state-machine smoke only.

## Caveats (called out in the commit messages)

- TCP **tail-kinematics** still falls back to head — needs pivot-offset columns in `kinematic_*.tsv`.
- **A-axis** paths (CA/AC/BA/AB orders) are gated off; `apply_tcp_correction` only honours CB/BC today.
- The **torque-limit slider** widget is still TODO; `tq` CLI verb works but the writeable HMI binding is its own change.
- Build is **CI-verified only** — no local cross-compiler available.

## Test plan
- [ ] CI builds both arm64 and rv64 cleanly
- [ ] Boot integration test reaches the CLI banner on arm64
- [ ] `test all` reports `0 failed` (new tcp / pallet / jobs subtests included)
- [ ] UI screenshot artefact picks up the new "LIVE STATE" panel on the service page and the new lights-out page

https://claude.ai/code/session_01Xg8kWJWXYK6g4NcuWw27rx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xg8kWJWXYK6g4NcuWw27rx)_