### PR TITLE
ui: raise widget/action caps so embedded_ui.tsv fits

### DIFF
--- a/ui/ui_builder_tsv.hpp
+++ b/ui/ui_builder_tsv.hpp
@@ -59,9 +59,15 @@ class Widget;
 
 namespace ui_builder {
 
-constexpr uint32_t MAX_WIDGETS = 256;
+// embedded_ui.tsv has ~953 widgets / ~169 actions raw, and 20 pages each
+// `include page=bottom_nav` — include_page_into_current clones bottom_nav's
+// 8 widgets and 7 actions into every including page, adding ~160 widgets
+// and ~140 actions. Working set is ~1113 widgets / ~309 actions; the prior
+// 256 / 128 caps aborted load_tsv mid-`machine_view` so no Widget* was
+// ever created and CI screenshots all rendered to a blank framebuffer.
+constexpr uint32_t MAX_WIDGETS = 1280;
 constexpr uint32_t MAX_PAGES = 32;
-constexpr uint32_t MAX_ACTIONS = 128;
+constexpr uint32_t MAX_ACTIONS = 384;
 constexpr uint32_t MAX_CHILD_LINKS = 256;
 constexpr uint32_t MAX_FIELD_LEN = 96;
 


### PR DESCRIPTION
ui_builder::load_tsv was aborting at line 472 of devices/embedded_ui.tsv
with "widget limit exceeded". The TSV declares ~953 widgets and 169
actions raw; 20 pages each `include page=bottom_nav`, and
include_page_into_current clones bottom_nav's 8 widgets / 7 actions into
the including page, so the working set is ~1113 widgets / ~309 actions.
The previous MAX_WIDGETS=256 cap blew up mid-`machine_view`, load_tsv
returned false before any Widget* was constructed, every page rendered
blank, and the UI screenshots workflow committed 19 byte-identical
336-byte PNGs to main on every refresh.

Bump MAX_WIDGETS to 1280 and MAX_ACTIONS to 384 — comfortable headroom
above the working set, ~760 KB extra .bss against a 128 MB image.