### PR TITLE
ui: unblock CI screenshot capture end-to-end

### DIFF
--- a/cpp_runtime_stubs.cpp
+++ b/cpp_runtime_stubs.cpp
@@ -22,7 +22,20 @@ extern "C" {
 }
 
 // --- Minimal new/delete ---
-#define KERNEL_SIMPLE_HEAP_SIZE (1024 * 256)
+// Bump allocator backing every kernel `operator new` — never freed, sized for
+// the full boot + first-render working set. The biggest consumers:
+//   - ui_builder::load_tsv constructs ~1113 BuilderXxx widgets (~220 KB)
+//   - render/machine_model.cpp imports several OBJ meshes (~32 KB scratch
+//     + per-mesh vertex/index blocks)
+//   - each BuilderImage running gles1::Renderer lazily allocates a
+//     widget-sized depth buffer (machine_view's preview pane is the
+//     largest at ~700 KB)
+//   - misc kernel bring-up paths (a few tens of KB)
+// The previous 256 KB cap OOM-panicked mid-tsv_load (every page rendered
+// blank, screenshots committed 336-byte placeholders); 2 MB still OOM'd at
+// machine_view's first render. 8 MB carries the full UI page-walk with
+// headroom. Costs 7.75 MB of .bss against the 128 MB QEMU image.
+#define KERNEL_SIMPLE_HEAP_SIZE (1024 * 1024 * 8)
 [[gnu::aligned(16)]] static char simple_kernel_heap[KERNEL_SIMPLE_HEAP_SIZE];
 static size_t simple_kernel_heap_ptr = 0;
 // This global Spinlock relies on its own constructor being called by call_constructors.

--- a/ui/fb.cpp
+++ b/ui/fb.cpp
@@ -240,10 +240,20 @@ Color Framebuffer::get_pixel(int32_t x, int32_t y) const {
 void Framebuffer::fill_rect(int32_t x, int32_t y, uint32_t w, uint32_t h, Color c) {
     if (x < 0) { if ((uint32_t)(-x) >= w) return; w -= (-x); x = 0; }
     if (y < 0) { if ((uint32_t)(-y) >= h) return; h -= (-y); y = 0; }
-    if (x + (int32_t)w > (int32_t)FB_WIDTH) w = FB_WIDTH - x;
-    if (y + (int32_t)h > (int32_t)FB_HEIGHT) h = FB_HEIGHT - y;
+    // Reject fully off-screen rects. The prior `(x + (int32_t)w) > FB_WIDTH`
+    // form overflowed signed int32 when w was untrusted/garbage: the addition
+    // wrapped negative, the comparison returned false, w was never clamped,
+    // and the inner loop walked off the end of buffer_ until it hit unmapped
+    // memory (FAR=0x48000000 on the QEMU virt -m 128M map). Test against
+    // FB_{WIDTH,HEIGHT} as unsigned upper bounds instead, then clamp w/h to
+    // the remaining slack.
+    if (static_cast<uint32_t>(x) >= FB_WIDTH || static_cast<uint32_t>(y) >= FB_HEIGHT) return;
+    const uint32_t max_w = FB_WIDTH - static_cast<uint32_t>(x);
+    const uint32_t max_h = FB_HEIGHT - static_cast<uint32_t>(y);
+    if (w > max_w) w = max_w;
+    if (h > max_h) h = max_h;
     if (w == 0 || h == 0) return;
-    
+
     uint32_t pixel = (c.a << 24) | (c.r << 16) | (c.g << 8) | c.b;
     for (uint32_t row = 0; row < h; ++row) {
         uint32_t* row_ptr = &buffer_[(y + row) * FB_WIDTH + x];

--- a/ui/splash.cpp
+++ b/ui/splash.cpp
@@ -515,8 +515,21 @@ void show_main_page(Framebuffer& fb) {
 
         if (timer) {
             const uint64_t now = timer->get_system_time_ns();
-            if (now > next_ns) next_ns = now;
-            else wait_until_ns(next_ns);
+            if (now > next_ns) {
+                // Render took longer than UI_PERIOD_NS. Still sleep for one
+                // full period before the next iteration so lower-priority
+                // threads on this core (cli prio=3, uart_io prio=3 vs ui
+                // prio=10) actually get scheduled. The old "next_ns = now"
+                // path skipped the wait entirely; on machine_view, where
+                // the 1040 × 1240 software GLES1 render takes ~1 s on
+                // QEMU TCG, that pegged the UI thread continuously and
+                // the cli thread never woke to dispatch the queued
+                // `ui_dump 6` command — `UI_DUMP_BEGIN` never reached
+                // the wire and CI screenshots aborted at machine_view
+                // with `timeout waiting for UI_DUMP_BEGIN`.
+                next_ns = now + UI_PERIOD_NS;
+            }
+            wait_until_ns(next_ns);
         } else {
             kernel::util::cpu_relax();
         }

--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -3103,7 +3103,17 @@ public:
                     text = kernel::ui::operator_api::offsets_snapshot().tool_name;
                     break;
                 default:
-                    format_bind_value(bind_, buf, sizeof(buf), spec_.text[0] ? spec_.text : "");
+                    // spec_.text is the placeholder shown before the bind
+                    // produces a value (e.g. "00:00:00" for an uptime, "---"
+                    // for an unbound IP). Don't pass it as prefix — every
+                    // bind formatter is "%s<value>", which would re-render
+                    // the placeholder in front of the live value and overflow
+                    // the widget. net_uptime_v (text="00:00:00",
+                    // bind=net:uptime, scale=2) produced "00:00:0000:00:00"
+                    // = 16 chars = 256 px, draw_x landing the tail at
+                    // x≥1080 — fb.fill_rect's bounds-check overflowed and
+                    // walked into unmapped MMIO at FAR=0x48000000.
+                    format_bind_value(bind_, buf, sizeof(buf), "");
                     text = buf;
                     break;
             }


### PR DESCRIPTION
PR #18 raised `MAX_WIDGETS` so `ui_builder::load_tsv` would ingest the full `devices/embedded_ui.tsv`, but the screenshot workflow still committed 19 byte-identical 336-byte placeholders on every refresh. Working through it surfaced four bugs, each masking the next:

## 1. Simple heap too small — kernel OOM mid-tsv_load (`cpu_runtime_stubs.cpp`)

`::operator new` is backed by a 256 KB bump allocator. With 1113 widgets at ~200 B each, plus `render/machine_model`'s OBJ scratch + per-mesh blocks plus `BuilderImage`'s lazy gles1 depth buffers (machine_view's is ~700 KB on its own), the kernel OOM-panicked partway through `tsv_load`. Bumped `KERNEL_SIMPLE_HEAP_SIZE` to 8 MB — comfortable headroom for the boot + first-render working set, costs 7.75 MB of `.bss` against the 128 MB QEMU image.

## 2. `Framebuffer::fill_rect` right-edge clamp was signed-int (`ui/fb.cpp`)

```cpp
if (x + (int32_t)w > (int32_t)FB_WIDTH) w = FB_WIDTH - x;
```

When `w` was large enough that `x + (int32_t)w` overflowed negative, the comparison silently returned false, `w` stayed huge, and the inner store loop walked off the end of the 8 MiB framebuffer until it hit unmapped memory at `FAR=0x48000000` (end of `-m 128M` RAM) — synchronous external abort, kernel dead. Switched to unsigned compares against `FB_{WIDTH,HEIGHT}` with early-reject for fully off-screen rects, then clamp w/h to the on-screen slack.

## 3. `BuilderLabel::render` double-rendered placeholder text (`ui/ui_builder_tsv.cpp`)

The default-branch call passed `spec_.text` as the `prefix` arg to `format_bind_value`. Every bind formatter is `"%s<value>"`, so the placeholder got prepended to the live value — `net_uptime_v` (`text="00:00:00" bind=net:uptime scale=2`) rendered `"00:00:0000:00:00"` (16 chars × 8 px × scale 2 = 256 px) into a 140-px-wide widget, overflowing right by 18 px and feeding fill_rect the bad coords that tripped bug 2. The other three callers of `format_bind_value` already pass `""`; do the same here. Special-case binds (Mode/Alarm/Prompt/ProgramName/...) still take their branches above the `default:` and are unaffected.

## 4. UI thread starved cli when render ran over budget (`ui/splash.cpp`)

`run_ui_main_loop`'s "render took longer than `UI_PERIOD_NS`" path did `next_ns = now` and skipped the wait — the loop ran continuously with no break. UI thread is prio 10, cli + uart_io are prio 3, all on core 0. `machine_view`'s ~1 s software GLES1 render pegged core 0 and the cli thread never woke to dispatch the queued `ui_dump 6`. Capture aborted at machine_view with `timeout waiting for UI_DUMP_BEGIN` while the boot UI thread happily kept printing `[virtio-gpu] flushes=N`. When over budget, advance `next_ns` by a full period and always wait — ~91 % UI CPU, ~9 % for cli/uart_io to drain queued input and emit the dump.

---

### Verification

Three back-to-back local runs of `scripts/qemu_dump_ui_pages.sh` each captured 20/20 pages with real content (13-30 distinct colors per page, dominant colour 30-66 %). Boot smoke gate still passes:

- `miniOS CLI ready.` banner emitted
- `echo` round-trips through the CLI
- `[ec0] cycle=250us` banner present and within ClearPath-EC budget
- No `PANIC`, no `[exc] unhandled`

### Commits

- `9f0d7c6` — runtime: 256 KB → 8 MB simple heap so UI fits
- `86b0756` — ui: clamp fill_rect bounds + stop double-rendering placeholder labels
- `f336380` — ui: yield one full period when the UI tick runs over budget
