### PR TITLE
Deep-dive review: correctness fixes across motion, render, CNC, EtherCAT, rv64, automation, util

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,13 @@ $(OBJDIR)/esm.o: ethercat/esm.cpp | $(OBJDIR)
 	$(CC) $(CFLAGS) -c -o $@ $<
 $(OBJDIR)/embedded_ui.o: devices/embedded_ui.S devices/embedded_ui.tsv | $(OBJDIR)
 	$(AS) $(ASFLAGS) -I. -x assembler-with-cpp -c -o $@ $<
-$(OBJDIR)/embedded_automation.o: devices/embedded_automation.S devices/embedded_macros.tsv devices/embedded_ladder.tsv devices/embedded_toolpods.tsv | $(OBJDIR)
+$(OBJDIR)/embedded_automation.o: devices/embedded_automation.S \
+                                  devices/embedded_macros.tsv \
+                                  devices/embedded_ladder.tsv \
+                                  devices/embedded_toolpods.tsv \
+                                  devices/embedded_pallets.tsv \
+                                  devices/embedded_jobs.tsv \
+                                  | $(OBJDIR)
 	$(AS) $(ASFLAGS) -I. -x assembler-with-cpp -c -o $@ $<
 $(OBJDIR)/embedded_signals.o: devices/embedded_signals.S devices/embedded_signals.tsv | $(OBJDIR)
 	$(AS) $(ASFLAGS) -I. -x assembler-with-cpp -c -o $@ $<
@@ -378,7 +384,17 @@ $(OBJDIR)/benchmark.o: render/benchmark.cpp | $(OBJDIR)
 # .incbin resolves paths relative to the assembler's include search paths
 # (-I). The rule runs from the project root, so `devices/clearpath_ec.tsv`
 # referenced inside embedded_blob.S resolves directly.
-$(OBJDIR)/embedded_blob.o: devices/embedded_blob.S devices/clearpath_ec.tsv | $(OBJDIR)
+$(OBJDIR)/embedded_blob.o: devices/embedded_blob.S \
+                            devices/clearpath_ec.tsv \
+                            devices/beckhoff_ek.tsv \
+                            devices/el5042_biss.tsv \
+                            devices/el1809_din.tsv \
+                            devices/el2809_dout.tsv \
+                            devices/el3162_ain.tsv \
+                            devices/el7201_9014_servo.tsv \
+                            devices/el7211_9014_servo.tsv \
+                            devices/el7221_9014_servo.tsv \
+                            | $(OBJDIR)
 	$(AS) $(ASFLAGS) -I. -x assembler-with-cpp -c -o $@ $<
 $(OBJDIR)/embedded_kinematics.o: devices/embedded_kinematics.S machines/kinematic_mill3.tsv machines/kinematic_millturn.tsv machines/kinematic_mx850.tsv | $(OBJDIR)
 	$(AS) $(ASFLAGS) -I. -x assembler-with-cpp -c -o $@ $<

--- a/automation/ladder_runtime.cpp
+++ b/automation/ladder_runtime.cpp
@@ -9,29 +9,32 @@ namespace ladder {
 
 namespace {
 
+// Accepts either a full record line OR a pre-split rest pointer.
+// See macro_runtime.cpp for the diagnosis; the prior form silently dropped
+// the first key=value when callers passed `rest`.
 const char* field_value(const char* line, const char* key, char* scratch, size_t scratch_size) {
     if (!line || !key || !scratch || scratch_size == 0) return nullptr;
     const char* p = line;
-    while (*p && *p != '\t') ++p;
-    while (*p == '\t') {
-        ++p;
+    for (;;) {
         const char* field = p;
         while (*p && *p != '\t') ++p;
         const char* eq = field;
         while (eq < p && *eq != '=') ++eq;
-        if (eq >= p) continue;
-        const size_t key_len = static_cast<size_t>(eq - field);
-        if (kernel::util::kstrlen(key) == key_len &&
-            kernel::util::kmemcmp(field, key, key_len) == 0) {
-            const char* value = eq + 1;
-            const size_t value_len = static_cast<size_t>(p - value);
-            const size_t copy = value_len + 1 < scratch_size ? value_len : scratch_size - 1;
-            for (size_t i = 0; i < copy; ++i) scratch[i] = value[i];
-            scratch[copy] = '\0';
-            return scratch;
+        if (eq < p) {
+            const size_t key_len = static_cast<size_t>(eq - field);
+            if (kernel::util::kstrlen(key) == key_len &&
+                kernel::util::kmemcmp(field, key, key_len) == 0) {
+                const char* value = eq + 1;
+                const size_t value_len = static_cast<size_t>(p - value);
+                const size_t copy = value_len + 1 < scratch_size ? value_len : scratch_size - 1;
+                for (size_t i = 0; i < copy; ++i) scratch[i] = value[i];
+                scratch[copy] = '\0';
+                return scratch;
+            }
         }
+        if (*p == '\0') return nullptr;
+        ++p;
     }
-    return nullptr;
 }
 
 const char* next_line(const char* p, const char* end, char* out, size_t out_size) {

--- a/automation/macro_runtime.cpp
+++ b/automation/macro_runtime.cpp
@@ -27,29 +27,37 @@ const char* next_line(const char* p, const char* end, char* out, size_t out_size
     return p;
 }
 
+// Accepts either a full record line ("kind\tkey1=val1\tkey2=val2") OR a
+// pre-split rest pointer that already starts at the first key=value. The
+// prior form unconditionally skipped past the first `\t`, which dropped the
+// first key when callers passed `rest` (the broken pattern in
+// macro_runtime/ladder_runtime/toolpods/machine_registry — see pallet.cpp's
+// comment for the original diagnosis). Treat every `\t`-separated token as
+// a candidate field; tokens with no `=` (the record-kind prefix) just fall
+// through.
 const char* field_value(const char* line, const char* key, char* scratch, size_t scratch_size) {
     if (!line || !key || !scratch || scratch_size == 0) return nullptr;
     const char* p = line;
-    while (*p && *p != '\t') ++p;
-    while (*p == '\t') {
-        ++p;
+    for (;;) {
         const char* field = p;
         while (*p && *p != '\t') ++p;
         const char* eq = field;
         while (eq < p && *eq != '=') ++eq;
-        if (eq >= p) continue;
-        const size_t key_len = static_cast<size_t>(eq - field);
-        if (kernel::util::kstrlen(key) == key_len &&
-            kernel::util::kmemcmp(field, key, key_len) == 0) {
-            const char* value = eq + 1;
-            const size_t value_len = static_cast<size_t>(p - value);
-            const size_t copy = value_len + 1 < scratch_size ? value_len : scratch_size - 1;
-            for (size_t i = 0; i < copy; ++i) scratch[i] = value[i];
-            scratch[copy] = '\0';
-            return scratch;
+        if (eq < p) {
+            const size_t key_len = static_cast<size_t>(eq - field);
+            if (kernel::util::kstrlen(key) == key_len &&
+                kernel::util::kmemcmp(field, key, key_len) == 0) {
+                const char* value = eq + 1;
+                const size_t value_len = static_cast<size_t>(p - value);
+                const size_t copy = value_len + 1 < scratch_size ? value_len : scratch_size - 1;
+                for (size_t i = 0; i < copy; ++i) scratch[i] = value[i];
+                scratch[copy] = '\0';
+                return scratch;
+            }
         }
+        if (*p == '\0') return nullptr;
+        ++p;  // skip the tab separator
     }
-    return nullptr;
 }
 
 long parse_long(const char* s, long fallback = 0) {

--- a/cnc/interpreter.cpp
+++ b/cnc/interpreter.cpp
@@ -357,7 +357,7 @@ bool Runtime::restart_at_line(size_t channel, size_t target_line) noexcept {
         // everything up to target_line. This isn't motion — it's just
         // bookkeeping inside state.targets[].
         if (parsed.axis_words[0] || parsed.axis_words[1] || parsed.axis_words[2] ||
-            parsed.axis_words[3] || parsed.axis_words[4] || parsed.axis_values[5]) {
+            parsed.axis_words[3] || parsed.axis_words[4] || parsed.axis_words[5]) {
             static constexpr char kAxisLetters[6] = {'X', 'Y', 'Z', 'A', 'B', 'C'};
             for (size_t word_idx = 0; word_idx < 6; ++word_idx) {
                 if (!parsed.axis_words[word_idx]) continue;

--- a/ethercat/master.cpp
+++ b/ethercat/master.cpp
@@ -181,7 +181,7 @@ void Master::handle_rx_frame(const uint8_t* data, size_t len) noexcept {
             // at offset 6 (after the 6-byte mailbox header); cmd byte at
             // offset 8. A download-direction response (master initiated)
             // has cmd nibble 0x60 (confirm) or 0x80 (abort).
-            if (dl_in_flight_ && station == dl_station_ && dg.data_len >= 12) {
+            if (dl_in_flight_.load(std::memory_order_acquire) && station == dl_station_ && dg.data_len >= 12) {
                 const uint8_t  cmd      = dg.data[8];
                 const uint16_t resp_idx =
                     static_cast<uint16_t>(dg.data[9]) |
@@ -656,14 +656,24 @@ bool Master::send_sdo_download_tracked(uint16_t station_addr,
                                        std::atomic<uint8_t>* completion_state,
                                        uint32_t* abort_code,
                                        uint32_t timeout_us) noexcept {
-    if (dl_in_flight_) return false;
+    // Atomically claim the single download slot — prior form had TOCTOU
+    // between the check and the write that let two concurrent callers
+    // both pass the gate, both clobber {station,index,sub,deadline,
+    // completion_state}, and the second's caller never saw their slot's
+    // completion update.
+    bool expected = false;
+    if (!dl_in_flight_.compare_exchange_strong(expected, true,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_relaxed)) {
+        return false;
+    }
     if (completion_state) completion_state->store(0, std::memory_order_release);
     if (abort_code) *abort_code = 0;
     if (!send_sdo_download(station_addr, index, sub, data, len_bytes)) {
         if (completion_state) completion_state->store(2, std::memory_order_release);
+        dl_in_flight_.store(false, std::memory_order_release);
         return false;
     }
-    dl_in_flight_   = true;
     dl_station_     = station_addr;
     dl_index_       = index;
     dl_sub_         = sub;
@@ -674,7 +684,7 @@ bool Master::send_sdo_download_tracked(uint16_t station_addr,
 }
 
 void Master::service_sdo_download() noexcept {
-    if (!dl_in_flight_) return;
+    if (!dl_in_flight_.load(std::memory_order_acquire)) return;
     // Poll SM1 mailbox for the slave's CoE response. Most slaves answer
     // an expedited download in <2 cycles; we issue one FPRD per cycle
     // until something lands or the deadline expires.
@@ -691,15 +701,15 @@ void Master::service_sdo_download() noexcept {
     if (now_us() <= dl_deadline_us_) return;
     if (dl_completion_) dl_completion_->store(2, std::memory_order_release);
     if (dl_abort_code_) *dl_abort_code_ = 0; // 0 = timeout
-    dl_in_flight_   = false;
     dl_completion_  = nullptr;
     dl_abort_code_  = nullptr;
+    dl_in_flight_.store(false, std::memory_order_release);
 }
 
 void Master::on_sdo_download_response(uint16_t station, uint8_t cmd,
                                       uint16_t index, uint8_t sub,
                                       uint32_t abort_code) noexcept {
-    if (!dl_in_flight_) return;
+    if (!dl_in_flight_.load(std::memory_order_acquire)) return;
     if (station != dl_station_ || index != dl_index_ || sub != dl_sub_) return;
     // CoE: cmd 0x60 = download confirm; cmd 0x80 = abort.
     if ((cmd & 0xE0) == 0x60) {
@@ -708,9 +718,9 @@ void Master::on_sdo_download_response(uint16_t station, uint8_t cmd,
         if (dl_completion_) dl_completion_->store(2, std::memory_order_release);
         if (dl_abort_code_) *dl_abort_code_ = abort_code;
     }
-    dl_in_flight_   = false;
     dl_completion_  = nullptr;
     dl_abort_code_  = nullptr;
+    dl_in_flight_.store(false, std::memory_order_release);
 }
 
 bool Master::enqueue_sdo_upload(const SdoRequest& req) noexcept {

--- a/ethercat/master.hpp
+++ b/ethercat/master.hpp
@@ -468,7 +468,13 @@ private:
     // download polls the deadline and fails out if the slave never
     // ack'd. Independent of upload state — a download and an upload can
     // be in flight concurrently (different mailbox slots).
-    bool                    dl_in_flight_   = false;
+    // Caller threads (cli, motion) and the cycle thread both touch this
+    // gate. Used to be a plain bool with TOCTOU between the
+    // send_sdo_download_tracked check at line ~659 and the write at line
+    // ~666 — two concurrent callers both passed and clobbered each
+    // other's completion_state/station/deadline. CAS-set from callers,
+    // release-store-false from cycle paths; mirror upload_busy_.
+    std::atomic<bool>       dl_in_flight_{false};
     uint16_t                dl_station_     = 0;
     uint16_t                dl_index_       = 0;
     uint8_t                 dl_sub_         = 0;

--- a/hal/riscv64/cpu_rv64.S
+++ b/hal/riscv64/cpu_rv64.S
@@ -515,5 +515,23 @@ cpu_context_switch_rv64:
     csrw    mepc, t0
     ld      t0, (TCB_MSTATUS_OFF)(a1)
     csrw    mstatus, t0
+
+    /* Clear g_irq_in_progress[hart] before mret — mirrors the trap-exit
+     * path at line ~422. The flag was set on entry (line ~467) so that a
+     * timer firing mid-switch would NOT spill into new_tcb. If we mret to
+     * the new thread without clearing, the flag stays at 1 and the next
+     * trap that fires on this hart skips its TCB save (trap_entry line
+     * ~291), then on trap-exit restores from a TCB whose caller-saved
+     * state was never written — corrupting pc/regs of whatever ran in
+     * between. Symptom: residual mcause=1 with mtval=0 / mepc landing on
+     * a stale-zero TCB.pc (the open CLAUDE.md rv64 boot regression).
+     * MIE is masked from line 455 onward so no trap can fire in this
+     * window; clearing is safe. */
+    csrr    t0, mhartid
+    lla     t1, g_irq_in_progress
+    slli    t2, t0, 3
+    add     t1, t1, t2
+    sd      zero, 0(t1)
+
     fence   i, rw                      /* sync instruction fetch with memory state */
     mret

--- a/machine/machine_registry.cpp
+++ b/machine/machine_registry.cpp
@@ -52,29 +52,32 @@ const char* next_line(const char* p, const char* end, char* out, size_t out_size
     return p;
 }
 
+// Accepts either a full record line OR a pre-split rest pointer.
+// See macro_runtime.cpp for the diagnosis; the prior form silently dropped
+// the first key=value when callers passed `rest`.
 const char* field_value(const char* line, const char* key, char* scratch, size_t scratch_size) {
     if (!line || !key || !scratch || scratch_size == 0) return nullptr;
     const char* p = line;
-    while (*p && *p != '\t') ++p;
-    while (*p == '\t') {
-        ++p;
+    for (;;) {
         const char* field = p;
         while (*p && *p != '\t') ++p;
         const char* eq = field;
         while (eq < p && *eq != '=') ++eq;
-        if (eq >= p) continue;
-        const size_t key_len = static_cast<size_t>(eq - field);
-        if (kernel::util::kstrlen(key) == key_len &&
-            kernel::util::kmemcmp(field, key, key_len) == 0) {
-            const char* value = eq + 1;
-            const size_t value_len = static_cast<size_t>(p - value);
-            const size_t copy = value_len + 1 < scratch_size ? value_len : scratch_size - 1;
-            for (size_t i = 0; i < copy; ++i) scratch[i] = value[i];
-            scratch[copy] = '\0';
-            return scratch;
+        if (eq < p) {
+            const size_t key_len = static_cast<size_t>(eq - field);
+            if (kernel::util::kstrlen(key) == key_len &&
+                kernel::util::kmemcmp(field, key, key_len) == 0) {
+                const char* value = eq + 1;
+                const size_t value_len = static_cast<size_t>(p - value);
+                const size_t copy = value_len + 1 < scratch_size ? value_len : scratch_size - 1;
+                for (size_t i = 0; i < copy; ++i) scratch[i] = value[i];
+                scratch[copy] = '\0';
+                return scratch;
+            }
         }
+        if (*p == '\0') return nullptr;
+        ++p;
     }
-    return nullptr;
 }
 
 long parse_long(const char* s, long fallback = 0) {

--- a/machine/toolpods.cpp
+++ b/machine/toolpods.cpp
@@ -20,29 +20,32 @@ const char* next_line(const char* p, const char* end, char* out, size_t out_size
     return p;
 }
 
+// Accepts either a full record line OR a pre-split rest pointer.
+// See macro_runtime.cpp for the diagnosis; the prior form silently dropped
+// the first key=value when callers passed `rest`.
 const char* field_value(const char* line, const char* key, char* scratch, size_t scratch_size) {
     if (!line || !key || !scratch || scratch_size == 0) return nullptr;
     const char* p = line;
-    while (*p && *p != '\t') ++p;
-    while (*p == '\t') {
-        ++p;
+    for (;;) {
         const char* field = p;
         while (*p && *p != '\t') ++p;
         const char* eq = field;
         while (eq < p && *eq != '=') ++eq;
-        if (eq >= p) continue;
-        const size_t key_len = static_cast<size_t>(eq - field);
-        if (kernel::util::kstrlen(key) == key_len &&
-            kernel::util::kmemcmp(field, key, key_len) == 0) {
-            const char* value = eq + 1;
-            const size_t value_len = static_cast<size_t>(p - value);
-            const size_t copy = value_len + 1 < scratch_size ? value_len : scratch_size - 1;
-            for (size_t i = 0; i < copy; ++i) scratch[i] = value[i];
-            scratch[copy] = '\0';
-            return scratch;
+        if (eq < p) {
+            const size_t key_len = static_cast<size_t>(eq - field);
+            if (kernel::util::kstrlen(key) == key_len &&
+                kernel::util::kmemcmp(field, key, key_len) == 0) {
+                const char* value = eq + 1;
+                const size_t value_len = static_cast<size_t>(p - value);
+                const size_t copy = value_len + 1 < scratch_size ? value_len : scratch_size - 1;
+                for (size_t i = 0; i < copy; ++i) scratch[i] = value[i];
+                scratch[copy] = '\0';
+                return scratch;
+            }
         }
+        if (*p == '\0') return nullptr;
+        ++p;
     }
-    return nullptr;
 }
 
 long parse_long(const char* s, long fallback = 0) {

--- a/motion/motion.cpp
+++ b/motion/motion.cpp
@@ -414,9 +414,14 @@ void Axis::step_trajectory(uint32_t dt_us) noexcept {
         traj_state = TrajState::Accel;
     }
 
-    // Apply acceleration or deceleration
-    int32_t a_tick = decel ? jerk_limited_accel : jerk_limited_accel;
-    if (decel) a_tick = -a_tick;
+    // Apply acceleration or deceleration. Sign is direction-aware:
+    //   dir > 0 accel:   a_tick = +|a|   (velocity grows positive)
+    //   dir > 0 decel:   a_tick = -|a|   (velocity shrinks toward 0)
+    //   dir < 0 accel:   a_tick = -|a|   (velocity grows negative)
+    //   dir < 0 decel:   a_tick = +|a|   (velocity climbs toward 0)
+    // The prior form unconditionally accelerated positive, so any axis
+    // commanded toward a negative target with dir<0 walked the wrong way.
+    int32_t a_tick = (decel ? -dir : dir) * jerk_limited_accel;
 
     const int64_t dv_num = (int64_t)a_tick * (int64_t)dt_us;
     const int32_t dv = (int32_t)(dv_num / 1'000'000LL);

--- a/render/machine_model.cpp
+++ b/render/machine_model.cpp
@@ -84,7 +84,10 @@ void create_cylinder(MeshPart& part, float radius, float height, int segments, g
     if (segments > 32) segments = 32;
 
     part.vertex_count = static_cast<size_t>(segments * 2 + 2);
-    part.index_count = static_cast<size_t>(segments * 6);
+    // 4 triangles per segment (top cap + bottom cap + 2 sides) × 3 indices.
+    // Prior `segments * 6` undersized the index buffer by 2× and the loop
+    // below at lines 109-127 wrote past the end of the allocation.
+    part.index_count = static_cast<size_t>(segments * 12);
     part.color = color;
 
     part.vertices = static_cast<gles1::Vertex*>(alloc_aligned(part.vertex_count * sizeof(gles1::Vertex)));

--- a/render/obj_importer.cpp
+++ b/render/obj_importer.cpp
@@ -170,9 +170,22 @@ bool parse_int(Cursor& cur, int32_t& out) {
 
     if (cur.ptr >= cur.end || *cur.ptr < '0' || *cur.ptr > '9') return false;
 
+    // Saturating accumulator — a malformed face line ("f 999999999999/...")
+    // used to overflow int32 with signed-overflow UB and feed a wrapped
+    // index into obj_index_to_zero_based, which then read past the
+    // positions/normals/uvs arrays. Clamp at INT32_MAX/MIN and stop the
+    // loop; caller already validates the value is in [1, max_*] before
+    // use.
+    constexpr int32_t kIntMax = 0x7FFFFFFF;
     int32_t value = 0;
     while (cur.ptr < cur.end && *cur.ptr >= '0' && *cur.ptr <= '9') {
-        value = value * 10 + static_cast<int32_t>(*cur.ptr - '0');
+        const int32_t digit = static_cast<int32_t>(*cur.ptr - '0');
+        if (value > (kIntMax - digit) / 10) {
+            value = kIntMax;
+            while (cur.ptr < cur.end && *cur.ptr >= '0' && *cur.ptr <= '9') ++cur.ptr;
+            break;
+        }
+        value = value * 10 + digit;
         ++cur.ptr;
     }
     out = value * sign;
@@ -216,6 +229,12 @@ bool parse_float(Cursor& cur, float& out) {
         ++cur.ptr;
         int32_t exponent = 0;
         if (!parse_int(cur, exponent)) return false;
+        // Cap the exponent at IEEE-754 single's range — anything past 38
+        // already saturates float, but the prior loop ran 1e9 iterations
+        // for a malformed `1e999999999` in input.
+        constexpr int32_t kMaxExp = 38;
+        if (exponent > kMaxExp) exponent = kMaxExp;
+        if (exponent < -kMaxExp) exponent = -kMaxExp;
         float scale = 1.0f;
         if (exponent > 0) {
             for (int32_t i = 0; i < exponent; ++i) scale *= 10.0f;

--- a/render/stl_importer.cpp
+++ b/render/stl_importer.cpp
@@ -76,11 +76,16 @@ bool parse_float(const char*& p, const char* end, float& out) {
         int esign = 1;
         if (p < end && *p == '+') ++p;
         else if (p < end && *p == '-') { esign = -1; ++p; }
+        // Cap exp at IEEE-754 single's range so the loop stays bounded and
+        // mul never silently inf/underflows from a multi-digit exponent in
+        // malformed input. Anything past 1e38 already saturates float.
+        constexpr int kMaxExp = 38;
         int exp = 0;
         while (p < end && *p >= '0' && *p <= '9') {
-            exp = exp * 10 + (*p - '0');
+            if (exp < kMaxExp + 1) exp = exp * 10 + (*p - '0');
             ++p;
         }
+        if (exp > kMaxExp) exp = kMaxExp;
         float mul = 1.0f;
         for (int i = 0; i < exp; ++i) mul *= 10.0f;
         value = (esign > 0) ? value * mul : value / mul;

--- a/util.cpp
+++ b/util.cpp
@@ -261,6 +261,9 @@ static int num_to_str_base_internal(uint64_t value, char* buffer, size_t buffer_
 int int_to_str(int32_t value, char* buffer, size_t buffer_size, int base) noexcept {
     return num_to_str_base_internal(static_cast<uint64_t>(static_cast<int64_t>(value)), buffer, buffer_size, base, true);
 }
+int int64_to_str(int64_t value, char* buffer, size_t buffer_size, int base) noexcept {
+    return num_to_str_base_internal(static_cast<uint64_t>(value), buffer, buffer_size, base, true);
+}
 int uint_to_str(uint32_t value, char* buffer, size_t buffer_size, int base) noexcept {
     return num_to_str_base_internal(value, buffer, buffer_size, base, false);
 }
@@ -419,7 +422,10 @@ int k_vsnprintf(char* buffer, size_t bufsz, const char* format, va_list args) no
                     break;
                 }
                 case 'd': case 'i': {
-                    if (is_long_long || is_size_t) current_segment_len = int_to_str(static_cast<int32_t>(va_arg(args, long long)), temp_num_buf, sizeof(temp_num_buf));
+                    // Prior form silently cast `long long` down to int32 — anything
+                    // past INT32_MAX (PSCI rc, motion frame counters, 64-bit ticks)
+                    // printed as garbage. Route 64-bit through int64_to_str instead.
+                    if (is_long_long || is_size_t) current_segment_len = int64_to_str(va_arg(args, long long), temp_num_buf, sizeof(temp_num_buf));
                     else current_segment_len = int_to_str(va_arg(args, int), temp_num_buf, sizeof(temp_num_buf));
                     break;
                 }

--- a/util.hpp
+++ b/util.hpp
@@ -113,6 +113,7 @@ bool ipv4_to_uint32(std::string_view ip_str, uint32_t& ip_addr) noexcept;
 
 // Number to string conversion helpers (definitions in util.cpp)
 int int_to_str(int32_t value, char* buffer, size_t buffer_size, int base = 10) noexcept;
+int int64_to_str(int64_t value, char* buffer, size_t buffer_size, int base = 10) noexcept;
 int uint_to_str(uint32_t value, char* buffer, size_t buffer_size, int base = 10) noexcept;
 int uint64_to_str(uint64_t value, char* buffer, size_t buffer_size, int base = 10) noexcept;
 int uint64_to_hex_str(uint64_t value, char* buffer, size_t buffer_size, bool leading_0x = true) noexcept;


### PR DESCRIPTION
Codebase-wide deep-dive review (six parallel agents covering CNC + G-code, motion + EtherCAT, 3D renderer, UI/HMI/CLI, kernel/sync + C++20 cross-cutting, build/scripts/fs/automation). The reviews surfaced ~100 findings; I prioritized correctness bugs with well-localized fixes, verified each, and applied them. Stylistic / idiomatic-only items were deferred — quality over volume.

Stacks on top of #19 (CI screenshot fixes still open). PR is opened against that branch so the diff shows only the new work; once #19 merges, retarget to `main`.

## Bugs fixed

**`c0c8c6c` Correctness fixes across motion, render, CNC, automation, util**

- `motion/motion.cpp:417` — `Axis::step_trajectory` could not accelerate in the negative direction. The prior form `int32_t a_tick = decel ? jerk_limited_accel : jerk_limited_accel; if (decel) a_tick = -a_tick;` ignored `dir`, so any axis commanded toward a negative target with `dir<0` walked the wrong way and never converged. Sign now folds `dir` into both phases.
- `render/machine_model.cpp:87` — `create_cylinder` reserved `segments * 6` index slots but the loop wrote `segments * 12` (4 triangles per segment × 3). Every spindle cylinder overran its index allocation; previously masked by the bump-heap layout.
- `cnc/interpreter.cpp:360` — restart-line dry-scan tested `parsed.axis_values[5]` (a float that's always 0 for the un-touched C slot) instead of `parsed.axis_words[5]`. C-axis-only lines were silently dropped from target tracking.
- `automation/macro_runtime.cpp`, `automation/ladder_runtime.cpp`, `machine/toolpods.cpp`, `machine/machine_registry.cpp` — four copies of `field_value()` walked past the first `\t` to skip the record-kind prefix, but every caller had *already* pre-advanced to a `rest` pointer. The first key=value (`id=`, `name=`, `source=`) silently never matched, leaving macros, ladder rungs, toolpod entries, and signal bindings with empty fields. `pallet.cpp` had diagnosed and worked around this; the other four were never updated. Each `field_value` now treats every `\t`-separated token as a candidate and works whether the caller passes a full line or a pre-split rest.
- `Makefile:310, Makefile:387` — `embedded_automation.o` declared 3 of its 5 `.incbin` prereqs (`embedded_pallets.tsv`, `embedded_jobs.tsv` missing); `embedded_blob.o` declared 1 of 9 (every Beckhoff/EL ESI TSV missing). Edits to the un-tracked TSVs left stale bytes in the kernel image with no rebuild signal.
- `util.cpp:421, util.hpp:115` — `k_vsnprintf`'s `%d/%i` with `ll`/`l`/`z` length modifiers cast through `int32_to_str`, truncating 64-bit values. ~149 call sites including PSCI rc / motion frame counters / system_time_ns. Added `int64_to_str` and routed the 64-bit path through it.

**`939bf9c` rv64: clear `g_irq_in_progress` before `mret` in voluntary context switch**

`cpu_context_switch_rv64` sets the flag on entry so a timer trap won't spill into `new_tcb`. The trap-EXIT path cleared the flag, but the voluntary-switch path never did. After a cooperative yield, the flag stayed at 1 for the rest of the new thread's life on this hart. The next trap saw `flag==1`, skipped its TCB save, then on exit restored from a TCB whose caller-saved state was never written — `mret` jumped to a stale or zero pc. Matches the residual `mcause=1, mtval=0, mepc=trap_entry's mret address` symptom that `CLAUDE.md`'s "Still blocked / open" rv64 section documents. Mirrors the trap-exit clear (MIE has been masked since `csrci mstatus` so no IRQ can fire in the clear window). The class of trap goes away after this; rv64 still hangs further into boot (`boot_ui_thread_entry`) but that's a separate pre-existing issue (the hang reproduces identically with this fix reverted).

**`4871042` ethercat: atomic `dl_in_flight_` to close SDO download TOCTOU**

`send_sdo_download_tracked` is callable from any thread (cli's torque-limit verb, motion's homing post-arm). The gate was a plain bool checked-then-written, so two concurrent callers both passed and clobbered each other's `{station,index,sub,deadline,completion_state}`. Mirror `upload_busy_`'s pattern: `std::atomic<bool>` with CAS to claim, release-store to relinquish. The cycle-thread paths (RX match, service poll, completion handler) switched to acquire-load and release-store. The `send_sdo_download` failure path now also relinquishes the slot so a transient TX error doesn't latch the gate permanently.

**`0f38649` render: cap `parse_int` / `parse_float` exponent against malformed input**

OBJ and STL parsers accept untrusted text from FAT32 / embedded blobs. Two latent UB / DoS paths:
- `parse_int` in obj_importer used `value = value*10 + digit` on int32 — signed-overflow UB on long digit runs, wrapped values then indexed off the end of the positions/normals/uvs tables. Saturate at INT32_MAX and bail.
- `parse_float` exponent paths in obj_importer and stl_importer looped 1e9 iterations of `scale *= 10` for `1e999999999`. Cap exponent at ±38 (IEEE-754 single's range — anything past saturates anyway).

## Findings reviewed but not applied (worth a follow-up)

The agents collectively flagged real issues that need bigger surgery; landing them here would balloon the PR. Highlights:

- `ui/ui_builder_tsv.cpp:4569` — `tick()` calls `mark_subtree_dirty()` every 100 ms, which forces every visible widget to re-render and defeats the present-skip optimization in `splash.cpp`. Right fix is bind-driven dirtying (formatters mark their owner when value changes); needs a careful audit of every formatter.
- `cnc/interpreter.cpp` `Runtime::snapshot()` reads channel state non-atomically across threads — torn snapshots are possible. Adding a per-channel lock around the snapshot is the right move.
- `core.cpp:285` Spinlock priority-boost has a narrow transitive-chain race where two concurrent boosters can leave the holder at the *lower* boosted priority. Fix is a CAS loop on the priority write.
- `render/gles1.cpp` near-plane `kNearW=0.001f` interacts with `shade_clipped`'s `cv.clip_pos.w <= 0.001f` discard; lerped vertices can fall on the wrong side of the threshold and be silently dropped. (`<` instead of `<=` or `kNearW * 0.999f`.)
- `ui/operator_api.cpp:1888-1942` `network_snapshot()` byte-order is inconsistent with the dotted-quad input parser (`commit_input_target` constructs big-endian-network-order; `local_ip` is stored host-order). Operator-typed pending vs live IP won't roundtrip.

Two agent claims I verified as **false positives** and skipped:

- `render/gles1.cpp:360` Sutherland-Hodgman "behind==1" winding — I walked through `bidx ∈ {0,1,2}` and the existing `(bidx+1)%3, (bidx+2)%3` pivot does preserve CCW (A0 is the next-CCW vertex after the behind one; the fan from A0 is CCW for all three pivots).
- `render/gles1.cpp:394` loop bound `v + 2 < out_count + 1` — equivalent to `v < out_count - 1`; with `v += 3` and `out_count ∈ {3, 6}`, v never lands at 4 and never reads past the end. Expression is confusingly written but not UB.

## Verification

- `make TARGET=arm64` clean
- `make TARGET=riscv64` clean
- arm64 boot smoke: `miniOS CLI ready` banner, `echo` round-trips, no `PANIC` / no `[exc] unhandled`, `[ec0] cycle=250us` banner present and within ClearPath-EC budget
- arm64 UI screenshot capture: 20/20 pages capture real content end-to-end via `scripts/qemu_dump_ui_pages.sh`
- rv64: no regression — the trap-spill class goes away (zero `[exc] unhandled` across 3 long-timeout boots); the pre-existing `boot_ui_thread_entry` hang reproduces identically with the rv64 fix reverted

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_