### PR TITLE
UI Phase A: bind-driven dirty + damage-rect present + container cap fix

### DIFF
--- a/hal.hpp
+++ b/hal.hpp
@@ -330,6 +330,14 @@ struct DisplayOps {
     virtual ~DisplayOps() = default;
     virtual bool init(void* framebuffer, uint32_t width, uint32_t height, uint32_t stride) = 0;
     virtual bool present() = 0;
+    // Damage-rect variant: transfer + flush only the given sub-rectangle
+    // instead of the full framebuffer. Backends that can't honour a partial
+    // rect should fall back to the full-screen present. (x,y,w,h) is in
+    // framebuffer pixels; the backend clips against the resolution.
+    virtual bool present_rect(uint32_t x, uint32_t y, uint32_t w, uint32_t h) {
+        (void)x; (void)y; (void)w; (void)h;
+        return present();
+    }
     virtual bool is_connected() = 0;
     virtual void get_resolution(uint32_t& width, uint32_t& height) = 0;
 };

--- a/hal/shared/virtio_gpu.cpp
+++ b/hal/shared/virtio_gpu.cpp
@@ -111,6 +111,10 @@ bool VirtioGpuDriver::present() {
     return flush();
 }
 
+bool VirtioGpuDriver::present_rect(uint32_t x, uint32_t y, uint32_t w, uint32_t h) {
+    return flush_rect(x, y, w, h);
+}
+
 bool VirtioGpuDriver::is_connected() {
     return initialized_;
 }
@@ -310,6 +314,10 @@ bool VirtioGpuDriver::init(uint64_t slot_base, uint32_t* framebuffer,
 }
 
 bool VirtioGpuDriver::flush() {
+    return flush_rect(0, 0, width_, height_);
+}
+
+bool VirtioGpuDriver::flush_rect(uint32_t x, uint32_t y, uint32_t w, uint32_t h) {
     if (!initialized_) {
         // Log once: the UI main loop flushes ~10 Hz, so spamming this every
         // frame on platforms where the GPU didn't probe (e.g. RV64 today)
@@ -320,15 +328,28 @@ bool VirtioGpuDriver::flush() {
         }
         return false;
     }
+    // Clip the damage rect against the scanout. Negative / zero w/h is a
+    // no-op present — the caller will have nothing to display.
+    if (x >= width_ || y >= height_) return true;
+    if (w == 0 || h == 0) return true;
+    if (x + w > width_)  w = width_  - x;
+    if (y + h > height_) h = height_ - y;
+
+    // Only flush the dirty band's cache lines, not the whole framebuffer.
     if (auto* mem = mem_ops()) {
-        mem->flush_cache_range(framebuffer_, stride_bytes_ * height_);
+        const size_t row_bytes = stride_bytes_;
+        const uintptr_t base = reinterpret_cast<uintptr_t>(framebuffer_) +
+                               static_cast<uintptr_t>(y) * row_bytes;
+        mem->flush_cache_range(reinterpret_cast<void*>(base), row_bytes * h);
     }
-    const Rect rect{0, 0, width_, height_};
+    const Rect rect{x, y, w, h};
+    const uint64_t offset = static_cast<uint64_t>(y) * stride_bytes_ +
+                            static_cast<uint64_t>(x) * 4u;
 
     auto transfer = zeroed<TransferToHost2D>();
     transfer.hdr.type = VIRTIO_GPU_CMD_TRANSFER_TO_HOST_2D;
     transfer.rect = rect;
-    transfer.offset = 0;
+    transfer.offset = offset;
     transfer.resource_id = RESOURCE_ID;
     response_ = {};
     if (!submit_command(&transfer, sizeof(transfer), &response_, sizeof(response_))) return false;
@@ -341,9 +362,6 @@ bool VirtioGpuDriver::flush() {
     const bool ok = submit_command(&flush_cmd, sizeof(flush_cmd), &response_, sizeof(response_));
     ++flush_count_;
     if (!ok) gpu_log("[virtio-gpu] RESOURCE_FLUSH failed\n");
-    // Heartbeat every 16 flushes (~1.6 s at UI loop's 100 ms cadence) so a
-    // silent GPU path is diagnosable from the serial log without a CLI stat
-    // dump. Cheap enough not to clog serial even at sustained 60 Hz.
     if ((flush_count_ & 0xF) == 0) {
         char buf[64];
         kernel::util::k_snprintf(buf, sizeof(buf),

--- a/hal/shared/virtio_gpu.hpp
+++ b/hal/shared/virtio_gpu.hpp
@@ -19,12 +19,14 @@ public:
     bool init(void* framebuffer, uint32_t width, uint32_t height,
               uint32_t stride) override;
     bool present() override;
+    bool present_rect(uint32_t x, uint32_t y, uint32_t w, uint32_t h) override;
     bool is_connected() override;
     void get_resolution(uint32_t& width, uint32_t& height) override;
 
     bool init(uint64_t slot_base, uint32_t* framebuffer, uint32_t width,
               uint32_t height, uint32_t stride_bytes);
     bool flush();
+    bool flush_rect(uint32_t x, uint32_t y, uint32_t w, uint32_t h);
 
     bool initialized() const { return initialized_; }
     uint64_t base() const { return base_; }

--- a/ui/display.cpp
+++ b/ui/display.cpp
@@ -22,4 +22,13 @@ bool present_display_backend() {
     return display->present();
 }
 
+bool present_display_backend_rect(uint32_t x, uint32_t y, uint32_t w, uint32_t h) {
+    auto* plat = kernel::g_platform;
+    if (!plat) return false;
+    auto* display = plat->get_display_ops();
+    if (!display) return false;
+    if (w == 0 || h == 0) return display->present();
+    return display->present_rect(x, y, w, h);
+}
+
 } // namespace kernel::ui

--- a/ui/display.hpp
+++ b/ui/display.hpp
@@ -2,9 +2,15 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace kernel::ui {
 
 bool init_display_backend();
 bool present_display_backend();
+// Damage-rect variant. Falls back to full-screen present when the display
+// backend doesn't override present_rect or when the rect collapses to
+// w==0/h==0 (typical for the heartbeat-only path).
+bool present_display_backend_rect(uint32_t x, uint32_t y, uint32_t w, uint32_t h);
 
 } // namespace kernel::ui

--- a/ui/fb.cpp
+++ b/ui/fb.cpp
@@ -222,19 +222,55 @@ void Framebuffer::clear(Color c) {
     for (size_t i = 0; i < FB_WIDTH * FB_HEIGHT; ++i) {
         buffer_[i] = pixel;
     }
-    dirty_ = true;
+    mark_dirty_rect(0, 0, FB_WIDTH, FB_HEIGHT);
 }
 
 void Framebuffer::set_pixel(int32_t x, int32_t y, Color c) {
     if (x < 0 || x >= (int32_t)FB_WIDTH || y < 0 || y >= (int32_t)FB_HEIGHT) return;
     buffer_[pixel_index(x, y)] = (c.a << 24) | (c.r << 16) | (c.g << 8) | c.b;
-    dirty_ = true;
+    mark_dirty_rect(x, y, 1, 1);
 }
 
 Color Framebuffer::get_pixel(int32_t x, int32_t y) const {
     if (x < 0 || x >= (int32_t)FB_WIDTH || y < 0 || y >= (int32_t)FB_HEIGHT) return Color::Black();
     uint32_t p = buffer_[pixel_index(x, y)];
     return Color((p >> 16) & 0xFF, (p >> 8) & 0xFF, p & 0xFF, (p >> 24) & 0xFF);
+}
+
+void Framebuffer::mark_dirty_rect(int32_t x, int32_t y, uint32_t w, uint32_t h) {
+    // Clamp to framebuffer bounds before unioning. Caller can pass negative
+    // x/y or oversized w/h (typical for off-screen widgets); we just clip
+    // them to the visible region.
+    if (x < 0) { if ((uint32_t)(-x) >= w) return; w -= (-x); x = 0; }
+    if (y < 0) { if ((uint32_t)(-y) >= h) return; h -= (-y); y = 0; }
+    if ((uint32_t)x >= FB_WIDTH || (uint32_t)y >= FB_HEIGHT) return;
+    const uint32_t max_w = FB_WIDTH - (uint32_t)x;
+    const uint32_t max_h = FB_HEIGHT - (uint32_t)y;
+    if (w > max_w) w = max_w;
+    if (h > max_h) h = max_h;
+    if (w == 0 || h == 0) return;
+    const uint32_t ux = (uint32_t)x;
+    const uint32_t uy = (uint32_t)y;
+    if (!dirty_ || damage_w_ == 0 || damage_h_ == 0) {
+        damage_x_ = ux;
+        damage_y_ = uy;
+        damage_w_ = w;
+        damage_h_ = h;
+    } else {
+        const uint32_t x1_existing = damage_x_ + damage_w_;
+        const uint32_t y1_existing = damage_y_ + damage_h_;
+        const uint32_t x1_new      = ux + w;
+        const uint32_t y1_new      = uy + h;
+        const uint32_t union_x = ux < damage_x_ ? ux : damage_x_;
+        const uint32_t union_y = uy < damage_y_ ? uy : damage_y_;
+        const uint32_t union_x1 = x1_existing > x1_new ? x1_existing : x1_new;
+        const uint32_t union_y1 = y1_existing > y1_new ? y1_existing : y1_new;
+        damage_x_ = union_x;
+        damage_y_ = union_y;
+        damage_w_ = union_x1 - union_x;
+        damage_h_ = union_y1 - union_y;
+    }
+    dirty_ = true;
 }
 
 void Framebuffer::fill_rect(int32_t x, int32_t y, uint32_t w, uint32_t h, Color c) {
@@ -261,7 +297,7 @@ void Framebuffer::fill_rect(int32_t x, int32_t y, uint32_t w, uint32_t h, Color 
             row_ptr[col] = pixel;
         }
     }
-    dirty_ = true;
+    mark_dirty_rect(x, y, w, h);
 }
 
 void Framebuffer::draw_rect(int32_t x, int32_t y, uint32_t w, uint32_t h, Color c, uint32_t line_width) {
@@ -385,16 +421,16 @@ void Framebuffer::blit(int32_t dx, int32_t dy, const uint32_t* src, uint32_t sw,
     for (uint32_t row = 0; row < sh; ++row) {
         int32_t dest_y = dy + row;
         if (dest_y < 0 || dest_y >= (int32_t)FB_HEIGHT) continue;
-        
+
         for (uint32_t col = 0; col < sw; ++col) {
             int32_t dest_x = dx + col;
             if (dest_x < 0 || dest_x >= (int32_t)FB_WIDTH) continue;
-            
+
             uint32_t src_idx = row * src_stride + col;
             buffer_[dest_y * FB_WIDTH + dest_x] = src[src_idx];
         }
     }
-    dirty_ = true;
+    mark_dirty_rect(dx, dy, sw, sh);
 }
 
 void Framebuffer::screenshot(uint32_t* out_buffer) const {

--- a/ui/fb.hpp
+++ b/ui/fb.hpp
@@ -93,10 +93,23 @@ public:
     // Copy region
     void blit(int32_t dx, int32_t dy, const uint32_t* src, uint32_t sw, uint32_t sh, uint32_t src_stride);
     
-    // Mark dirty (for hardware sync)
-    void mark_dirty() { dirty_ = true; }
+    // Mark dirty (for hardware sync). The legacy mark_dirty() is now
+    // shorthand for the full-screen damage rect; callers that know
+    // their bounds should prefer mark_dirty_rect for the partial
+    // present_rect path.
+    void mark_dirty() { mark_dirty_rect(0, 0, FB_WIDTH, FB_HEIGHT); }
+    void mark_dirty_rect(int32_t x, int32_t y, uint32_t w, uint32_t h);
     bool is_dirty() const { return dirty_; }
-    void clear_dirty() { dirty_ = false; }
+    void clear_dirty() {
+        dirty_ = false;
+        damage_x_ = 0; damage_y_ = 0; damage_w_ = 0; damage_h_ = 0;
+    }
+    // Damage rect for the next present. Clipped to (FB_WIDTH, FB_HEIGHT).
+    // Coordinates are valid only when is_dirty() is true.
+    uint32_t damage_x() const { return damage_x_; }
+    uint32_t damage_y() const { return damage_y_; }
+    uint32_t damage_w() const { return damage_w_; }
+    uint32_t damage_h() const { return damage_h_; }
     
     // Get/Set pixel fast (inline for performance)
     inline uint32_t pixel_index(int32_t x, int32_t y) const {
@@ -115,6 +128,14 @@ public:
     uint32_t* raw_buffer() { return buffer_; }
     uint32_t* buffer_;
     bool dirty_;
+    // Damage rect for partial present. Updated by mark_dirty_rect, read by
+    // present_display_backend. When dirty_ is true but damage_w/h are 0, the
+    // present-skip path (heartbeat-only) handles it by falling back to a
+    // full present.
+    uint32_t damage_x_ = 0;
+    uint32_t damage_y_ = 0;
+    uint32_t damage_w_ = 0;
+    uint32_t damage_h_ = 0;
     
     // Simple 8x16 bitmap font (ASCII 32-126)
     static const uint8_t font_8x16[95][16];

--- a/ui/splash.cpp
+++ b/ui/splash.cpp
@@ -508,7 +508,15 @@ void show_main_page(Framebuffer& fb) {
 
         ++ticks_since_present;
         if (fb.is_dirty() || ticks_since_present >= HEARTBEAT_TICKS) {
-            (void)present_display_backend();
+            // Damage-rect present: transfer only the rectangle that
+            // changed, not the full 1080 × 1920 × 4 = ~8 MB. A typical
+            // DRO update touches one ~100 × 32 px label = 12.8 KB instead
+            // of the full frame — three orders of magnitude less host
+            // emulation work on virtio-gpu. The heartbeat path
+            // (ticks_since_present == HEARTBEAT_TICKS) calls present_rect
+            // with w=h=0 so it falls back to a full present.
+            (void)present_display_backend_rect(fb.damage_x(), fb.damage_y(),
+                                               fb.damage_w(), fb.damage_h());
             fb.clear_dirty();
             ticks_since_present = 0;
         }

--- a/ui/ui.hpp
+++ b/ui/ui.hpp
@@ -179,7 +179,17 @@ public:
     }
 
 protected:
-    std::array<Widget*, 32> children_;
+    // Per-container child capacity. The pages that ship today carry up to
+    // ~100 children on the offsets page (96 widgets under `offsets_root`),
+    // so 32 silently dropped 64 of them — the lower half of the offsets
+    // page rendered empty in screenshots (sampled at y=1200 showed only
+    // bg+border, no widget pixels). 128 fits every shipped page with
+    // headroom and costs an extra 768 bytes per Container instance
+    // (~75 KB total .bss against the 96 panels/containers + BuilderRoot
+    // + a handful of misc Container singletons — negligible vs the 8 MB
+    // heap and 128 MB QEMU image).
+    static constexpr size_t MAX_CHILDREN = 128;
+    std::array<Widget*, MAX_CHILDREN> children_;
     size_t child_count_;
 };
 

--- a/ui/ui.hpp
+++ b/ui/ui.hpp
@@ -91,6 +91,16 @@ public:
     void mark_dirty() { needs_redraw_ = true; }
     virtual void mark_subtree_dirty() { mark_dirty(); }
 
+    // Bind-driven dirty: called once per UI tick on every visible widget.
+    // Bound widgets override to compare the current bind value against an
+    // internal cache and call mark_dirty() only when the value changed.
+    // Default no-op for widgets with no bind state. Container overrides
+    // to descend into visible children. Phase-A foundation: replaces the
+    // prior `tick()` blanket `mark_subtree_dirty()` that forced every
+    // widget to re-render every 100 ms and defeated the present-skip
+    // optimization in splash.cpp.
+    virtual void poll_bind_dirty() {}
+
 protected:
     int32_t x_, y_;
     uint32_t width_, height_;
@@ -137,6 +147,15 @@ public:
                 child->render(fb);
                 child->clear_redraw();
             }
+        }
+    }
+
+    void poll_bind_dirty() override {
+        // Descend into visible children only — invisible pages don't need
+        // their bound widgets polled.
+        for (size_t i = 0; i < child_count_; ++i) {
+            Widget* child = children_[i];
+            if (child && child->visible()) child->poll_bind_dirty();
         }
     }
     

--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -3071,52 +3071,40 @@ public:
         }
     }
 
+    // Resolve the current bind value into `out`. Returns the pointer the
+    // caller should use as the text — either a const string from the
+    // snapshot/special-case branch (in which case `out` is unused) or
+    // `out` itself (filled by format_bind_value for the default branch).
+    // Shared between render() (drawing) and poll_bind_dirty() (change
+    // detection) so a future bind formatter shape change can't drift the
+    // two paths apart.
+    const char* compute_text(char* out, size_t out_size) const {
+        if (bind_ == BindKind::None) return spec_.text;
+        const auto snap = kernel::ui::operator_api::machine_snapshot();
+        switch (bind_) {
+            case BindKind::Mode: return mode_text(snap.mode);
+            case BindKind::Alarm:
+                return snap.mode == kernel::ui::operator_api::Mode::Alarm ? "ALARM ACTIVE" : "ALARMS CLEAR";
+            case BindKind::Prompt:
+                return snap.mode == kernel::ui::operator_api::Mode::Running ? "CYCLE RUN IN PROGRESS" : "READY FOR COMMAND";
+            case BindKind::PageName:        return active_page_title();
+            case BindKind::ProgramName:     return kernel::ui::operator_api::selected_program_name();
+            case BindKind::WorkName:        return kernel::ui::operator_api::offsets_snapshot().workset_name;
+            case BindKind::ToolName:        return kernel::ui::operator_api::offsets_snapshot().tool_name;
+            default:
+                format_bind_value(bind_, out, out_size, "");
+                return out;
+        }
+    }
+
     void render(Framebuffer& fb) override {
         if (!visible_) return;
-        const char* text = spec_.text;
         char buf[MAX_FIELD_LEN] = {};
+        const char* text = compute_text(buf, sizeof(buf));
         Color fg = fg_;
         if (active_bind_ != BindKind::None &&
             bound_numeric_value(active_bind_) == active_value_) {
             fg = Color(0xEF, 0x44, 0x44);
-        }
-        if (bind_ != BindKind::None) {
-            const auto snap = kernel::ui::operator_api::machine_snapshot();
-            switch (bind_) {
-                case BindKind::Mode: text = mode_text(snap.mode); break;
-                case BindKind::Alarm:
-                    text = snap.mode == kernel::ui::operator_api::Mode::Alarm ? "ALARM ACTIVE" : "ALARMS CLEAR";
-                    break;
-                case BindKind::Prompt:
-                    text = snap.mode == kernel::ui::operator_api::Mode::Running ? "CYCLE RUN IN PROGRESS" : "READY FOR COMMAND";
-                    break;
-                case BindKind::PageName:
-                    text = active_page_title();
-                    break;
-                case BindKind::ProgramName:
-                    text = kernel::ui::operator_api::selected_program_name();
-                    break;
-                case BindKind::WorkName:
-                    text = kernel::ui::operator_api::offsets_snapshot().workset_name;
-                    break;
-                case BindKind::ToolName:
-                    text = kernel::ui::operator_api::offsets_snapshot().tool_name;
-                    break;
-                default:
-                    // spec_.text is the placeholder shown before the bind
-                    // produces a value (e.g. "00:00:00" for an uptime, "---"
-                    // for an unbound IP). Don't pass it as prefix — every
-                    // bind formatter is "%s<value>", which would re-render
-                    // the placeholder in front of the live value and overflow
-                    // the widget. net_uptime_v (text="00:00:00",
-                    // bind=net:uptime, scale=2) produced "00:00:0000:00:00"
-                    // = 16 chars = 256 px, draw_x landing the tail at
-                    // x≥1080 — fb.fill_rect's bounds-check overflowed and
-                    // walked into unmapped MMIO at FAR=0x48000000.
-                    format_bind_value(bind_, buf, sizeof(buf), "");
-                    text = buf;
-                    break;
-            }
         }
         fb.fill_rect(x_, y_, width_, height_, bg_);
         const uint32_t scale = spec_.text_scale > 0 ? spec_.text_scale : 1u;
@@ -3133,6 +3121,26 @@ public:
         }
     }
 
+    void poll_bind_dirty() override {
+        // Static labels (no bind, no active_if) never change. The initial
+        // dirty flag set in Widget's ctor renders them once, then they
+        // stay clean for the rest of the page's lifetime.
+        if (bind_ == BindKind::None && active_bind_ == BindKind::None) return;
+        char buf[MAX_FIELD_LEN] = {};
+        const char* text = compute_text(buf, sizeof(buf));
+        const int8_t active_match = (active_bind_ != BindKind::None)
+            ? static_cast<int8_t>(bound_numeric_value(active_bind_) == active_value_ ? 1 : 0)
+            : static_cast<int8_t>(-1);
+        // Compare text + active_if state against last poll. mark_dirty()
+        // only when something actually changed.
+        if (active_match != last_active_match_ ||
+            kernel::util::kstrcmp(text, last_text_) != 0) {
+            kernel::util::safe_strcpy(last_text_, text, sizeof(last_text_));
+            last_active_match_ = active_match;
+            mark_dirty();
+        }
+    }
+
 private:
     WidgetSpec spec_;
     Color fg_;
@@ -3140,6 +3148,9 @@ private:
     BindKind bind_;
     BindKind active_bind_ = BindKind::None;
     int32_t  active_value_ = 0;
+    // Bind-change cache (see poll_bind_dirty).
+    char    last_text_[MAX_FIELD_LEN]{};
+    int8_t  last_active_match_ = -1;  // -1 = unknown, 0 = no, 1 = yes
 };
 
 class BuilderButton final : public kernel::ui::Button {
@@ -3184,6 +3195,34 @@ public:
     bool active_if_matches() const {
         if (active_bind_ == BindKind::None) return false;
         return bound_numeric_value(active_bind_) == active_value_;
+    }
+
+    void poll_bind_dirty() override {
+        // A button's visual state changes when: (a) its bound label text
+        // changes, (b) active_if flips, or (c) the active page changes
+        // (affects the "you are here" highlight on goto: targets).
+        // Compare each against the cached state and mark_dirty only on
+        // change.
+        char label_buf[MAX_FIELD_LEN] = {};
+        const char* label = spec_.text;
+        if (bind_ != BindKind::None) {
+            format_bind_value(bind_, label_buf, sizeof(label_buf), "");
+            if (label_buf[0] != '\0') label = label_buf;
+        }
+        const int8_t active_match = (active_bind_ != BindKind::None)
+            ? static_cast<int8_t>(active_if_matches() ? 1 : 0)
+            : static_cast<int8_t>(-1);
+        const char* target = action_target_for_widget(spec_.id, BuilderEvent::Click, spec_.action);
+        const int8_t goto_self = (target && kernel::util::kstrncmp(target, "goto:", 5) == 0)
+            ? static_cast<int8_t>(find_page_index_by_id(target + 5) == g_active_page ? 1 : 0)
+            : static_cast<int8_t>(-1);
+        if (active_match != last_active_match_ || goto_self != last_goto_self_ ||
+            kernel::util::kstrcmp(label, last_label_) != 0) {
+            kernel::util::safe_strcpy(last_label_, label, sizeof(last_label_));
+            last_active_match_ = active_match;
+            last_goto_self_ = goto_self;
+            mark_dirty();
+        }
     }
 
     void render(Framebuffer& fb) override {
@@ -3286,6 +3325,10 @@ private:
     BindKind active_bind_ = BindKind::None;
     int32_t active_value_ = 0;
     BindKind bind_ = BindKind::None;
+    // Bind-change cache (see poll_bind_dirty).
+    char    last_label_[MAX_FIELD_LEN]{};
+    int8_t  last_active_match_ = -1;
+    int8_t  last_goto_self_ = -1;
 };
 
 class BuilderPanel final : public Panel {
@@ -3346,8 +3389,18 @@ public:
         kernel::ui::ProgressBar::render(fb);
     }
 
+    void poll_bind_dirty() override {
+        if (bind_ == BindKind::None) return;
+        const int32_t v = bound_numeric_value(bind_);
+        if (v != last_value_) {
+            last_value_ = v;
+            mark_dirty();
+        }
+    }
+
 private:
     BindKind bind_;
+    int32_t last_value_ = -2147483647 - 1;  // INT32_MIN: definitely different from first read
 };
 
 class BuilderGraph final : public kernel::ui::BarGraph {
@@ -3379,8 +3432,34 @@ public:
         kernel::ui::BarGraph::render(fb);
     }
 
+    void poll_bind_dirty() override {
+        if (bind_ == BindKind::None) return;
+        // For axis-bound bar graphs we track the snapshot's 4-axis vector;
+        // for any single-bind graph we track the numeric value.
+        if (bind_ == BindKind::AxisX || bind_ == BindKind::AxisY ||
+            bind_ == BindKind::AxisZ || bind_ == BindKind::AxisA) {
+            const auto snap = kernel::ui::operator_api::machine_snapshot();
+            int32_t v[4] = {snap.axis_pos[0], snap.axis_pos[1], snap.axis_pos[2], snap.axis_pos[3]};
+            for (int i = 0; i < 4; ++i) {
+                if (v[i] != last_values_[i]) {
+                    for (int j = 0; j < 4; ++j) last_values_[j] = v[j];
+                    mark_dirty();
+                    return;
+                }
+            }
+        } else {
+            const int32_t v = bound_numeric_value(bind_);
+            if (v != last_values_[0]) {
+                last_values_[0] = v;
+                mark_dirty();
+            }
+        }
+    }
+
 private:
     BindKind bind_;
+    int32_t  last_values_[4] = {-2147483647 - 1, -2147483647 - 1,
+                                -2147483647 - 1, -2147483647 - 1};
 };
 
 class BuilderSlider final : public Widget {
@@ -3466,6 +3545,19 @@ public:
         return false;
     }
 
+    void poll_bind_dirty() override {
+        // Sliders being dragged manage their own dirty via update_from_x.
+        // For a settled slider with a live bind, mark dirty only when the
+        // bound value changes — feed/spindle overrides set from the CLI or
+        // a peer override slider on another page.
+        if (dragging_ || bind_ == BindKind::None) return;
+        const int32_t v = bound_numeric_value(bind_);
+        if (v != last_value_) {
+            last_value_ = v;
+            mark_dirty();
+        }
+    }
+
 private:
     void update_from_x(int32_t x) {
         float ratio = 0.0f;
@@ -3488,6 +3580,7 @@ private:
     int32_t value_;
     bool hovered_;
     bool dragging_;
+    int32_t last_value_ = -2147483647 - 1;
 };
 
 class BuilderInput final : public Widget {
@@ -3505,6 +3598,23 @@ public:
     void tick_feedback() {
         if (feedback_ticks_ > 0) {
             --feedback_ticks_;
+            mark_dirty();
+        }
+    }
+
+    void poll_bind_dirty() override {
+        // While focused, the buffer holds operator-typed text — value
+        // changes from the bind source don't apply (the operator's edit
+        // wins until commit/blur). Once unfocused, the bind value flows
+        // back in via the render() refresh. Detect changes here so the
+        // mark_dirty happens before render and we don't repaint when
+        // nothing changed.
+        if (focused_ || bind_ == BindKind::None) return;
+        char fresh[MAX_FIELD_LEN] = {};
+        format_bind_value(bind_, fresh, sizeof(fresh), "");
+        if (kernel::util::kstrcmp(fresh, buffer_) != 0) {
+            // Render() will re-format into buffer_ from the bind; we only
+            // need the dirty signal.
             mark_dirty();
         }
     }
@@ -3671,6 +3781,16 @@ public:
         camera_.pitch = 0.5f;
         camera_.dist = camera_.dual_channel_default ? 6.2f : 4.4f;
         mark_dirty();
+    }
+
+    void poll_bind_dirty() override {
+        // GLES1 widgets render live machine state every frame the page is
+        // visible — axis positions, tool position, etc. all drive the
+        // scene and they update at the motion cycle rate (250 µs).
+        // Static fallback images don't change after first paint.
+        if (kernel::util::kstrncmp(spec_.text, "gles1:", 6) == 0) {
+            mark_dirty();
+        }
     }
 
     void render(Framebuffer& fb) override {
@@ -4566,7 +4686,14 @@ void tick() {
         if (g_inputs[i]) g_inputs[i]->tick_feedback();
     }
     cnc::mdi::g_service.tick();
-    if (g_root_widget) g_root_widget->mark_subtree_dirty();
+    // Bind-driven dirty: each bound widget compares its current value
+    // against an internal cache and calls mark_dirty() only when the
+    // value changed. Container::poll_bind_dirty() descends into visible
+    // children, so invisible pages don't pay for the walk. Replaces the
+    // prior blanket mark_subtree_dirty() that forced every widget on
+    // every page to re-render every 100 ms and defeated the present-skip
+    // optimization in splash.cpp's main UI loop.
+    if (g_root_widget) g_root_widget->poll_bind_dirty();
 }
 
 } // namespace ui_builder

--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -3762,6 +3762,20 @@ public:
         }
     }
 
+    ~BuilderImage() override {
+        // Release the lazy depth buffer (allocated by ensure_depth_buffer
+        // via ::operator new). The bump heap can't actually reclaim the
+        // bytes, but the matching delete here keeps the path correct for
+        // any future real allocator and documents the ownership. Until
+        // hot reload lands the destructor never fires; setting it up now
+        // means widget lifecycles are correct end-to-end when it does.
+        if (depth_buffer_) {
+            ::operator delete(depth_buffer_);
+            depth_buffer_ = nullptr;
+            depth_capacity_ = 0;
+        }
+    }
+
     static void reset_all_cameras() {
         for (uint32_t i = 0; i < g_gles1_widget_count; ++i) {
             if (g_gles1_widgets[i]) g_gles1_widgets[i]->reset_camera();


### PR DESCRIPTION
First PR in the phased UI/UX series. Phase A is the runtime foundation that later phases (authoring DX, themes, animations, gestures, CI tooling) depend on.

3 of 4 Phase-A items land here; A4 (modal/overlay Z-layer) is a TSV schema extension and ships as its own PR.

## A1 — Bind-driven dirty tracking (`2dd6085`)

`ui_builder::tick()` was unconditionally calling `mark_subtree_dirty()` every 100 ms. Every widget on every page (visible or not) was marked dirty, so `Container::render`'s "only descend into needs_redraw children" optimization was dead and every UI tick repainted the full framebuffer. `fb.is_dirty()` was true on every tick, the present-skip gate in `splash.cpp` was unreachable, and virtio-gpu transfers ran at ~10 Hz × 8 MB even on a truly idle page.

Replaced the blanket mark with per-widget bind-change detection:

| Widget | Cache | Marks dirty when... |
|---|---|---|
| `BuilderLabel` | text buffer + active_if state | text or active_if changes |
| `BuilderButton` | label + active_if + goto-self | any changes |
| `BuilderProgress` | last numeric value | value changes |
| `BuilderGraph` | last 4 numeric values | any axis value changes |
| `BuilderSlider` | last numeric value | value changes (skipped while dragging) |
| `BuilderInput` | bind value | changes (skipped while focused) |
| `BuilderImage` | n/a — 3D scene drives off live state | always dirty |

`BuilderLabel`'s bind dispatch is factored into `compute_text()` shared by `render()` and `poll_bind_dirty()` so the two paths can't drift apart.

**Result:** virtio-gpu flush count across a 20-page capture run drops from thousands to ~48.

## A2 — Damage-rect rendering (`433c484`)

Each present transferred 1080 × 1920 × 4 = ~8 MB through `TRANSFER_TO_HOST_2D` + `RESOURCE_FLUSH` on every flush, even when only a single DRO digit changed.

- `Framebuffer` tracks a unioned damage rect (`damage_x_/y_/w_/h_`).
- `fill_rect`/`clear`/`blit`/`set_pixel` call `mark_dirty_rect` with their actual bounds instead of unconditionally setting `dirty_=true`.
- `DisplayOps::present_rect(x,y,w,h)` added — defaults to `present()` for backends that can't do partial transfer.
- `VirtioGpuDriver::flush_rect()` clips against scanout, `flush_cache_range`s only the rect's rows, and submits `TRANSFER_TO_HOST_2D` + `RESOURCE_FLUSH` with the sub-rect (correct stride offset).
- `present_display_backend_rect()` threads the rect through; `w=0/h=0` falls back to a full present (heartbeat path).

A typical bound label is ~140 × 56 px = 31 KB — **260× less host emulation work** per present than the prior full-frame transfer.

## A3 — Widget lifecycle + container cap (`dd02386`)

Two related fixes:

**`Container::children_` was capped at 32, silently dropping any child past index 32.** `embedded_ui.tsv` has pages with up to 96 widgets parented to a single panel — the `offsets` page uses `offsets_root` as a flat container for the title row, DRO inputs, the 6×4 WCS grid, and the tool table. The first 32 made it into the tree; the remaining 64 fell on the floor.

Verified directly by sampling the rendered PPM:

|  | y=480 | y=1200 | y=1740 |
|---|---|---|---|
| before | 6 colors | 2 colors (bg + border, no widgets) | 1 color |
| after  | 7 colors | **5 colors (G55..G59 rows + tool table)** | 1 color |

Bumped `MAX_CHILDREN` to 128 (`~75 KB` extra `.bss` across the ~97 Container instances at boot).

**`BuilderImage` gained a destructor** that `::operator delete`s the lazy `depth_buffer_`. The bump heap can't reclaim bytes today, but the matching delete keeps the path correct for any future real allocator and documents ownership. Hot reload isn't wired yet — once it is, widget lifecycle is now end-to-end correct.

## A4 deferred

Modal/overlay Z-layer is a TSV schema extension (new `dialog` record type) + a render-layer above the page tree. Self-contained scope, better as its own PR rather than padding this one.

## Verification

- `make TARGET=arm64` clean
- Boot smoke gate: CLI ready, echo, `[ec0] cycle=250us`, no PANIC / `[exc] unhandled`
- All 20 UI screenshot pages capture real content via `scripts/qemu_dump_ui_pages.sh`
- offsets page now shows the previously-dropped widgets (see attached PPM sampling above)
- virtio-gpu flush count: ~48 across the 20-page capture run vs thousands previously

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_