### PR TITLE
UI A4: modal dialog Z-layer above pages

### DIFF
--- a/devices/embedded_ui.tsv
+++ b/devices/embedded_ui.tsv
@@ -1640,8 +1640,13 @@ include	page=bottom_nav
 # confirm_restart() — operator must inspect tool / WCS / spindle /
 # coolant against what is physically mounted before resuming.
 # ============================================================
-page	id=restart_confirm	title=Restart Confirm
-panel	id=rc_root	x=0	y=0	w=1080	h=1740	bg=#0A0F1A	border=#1F2937
+# Modal dialog (see A4 in ui_builder_tsv): opened via
+# `action=dialog:show:restart_confirm` from the program page, closed by
+# the CANCEL button's dialog:close action. The dim slate-900 backdrop
+# rendered by BuilderRoot keeps the operator's prior context visible
+# behind the wizard.
+dialog	id=restart_confirm	title=Restart Confirm
+panel	id=rc_root	x=60	y=160	w=960	h=1400	bg=#0A0F1A	border=#1F2937
 label	id=rc_title	parent=rc_root	x=40	y=30	w=1000	h=40	text=RESTART AT LINE -- CONFIRM	color=#F8FAFC	bg=#0A0F1A	align=center	scale=2
 label	id=rc_subtitle	parent=rc_root	x=40	y=72	w=1000	h=24	text=Verify the reconstructed state matches the physical machine before tapping CONFIRM.	color=#FCA5A5	bg=#0A0F1A	align=center	scale=1
 
@@ -1673,8 +1678,9 @@ button	id=rc_confirm	parent=rc_root	x=40	y=940	w=480	h=300	text=CONFIRM RESTART	
 button	id=rc_cancel	parent=rc_root	x=540	y=940	w=480	h=300	text=CANCEL	bg=#B91C1C	color=#FFFFFF	scale=3	focus=942
 
 action	widget=rc_confirm	event=click	target=restart:confirm
-action	widget=rc_cancel	event=click	target=restart:cancel
-include	page=bottom_nav
+action	widget=rc_cancel	event=click	target=dialog:close
+# Dialogs render above the active page; no bottom_nav include — the dialog
+# doesn't navigate, it just confirms-or-cancels.
 
 # ============================================================
 # lights_out -- per-pallet status grid + job scheduler controls.

--- a/scripts/qemu_dump_ui_pages.sh
+++ b/scripts/qemu_dump_ui_pages.sh
@@ -42,7 +42,13 @@ PAGE_ORDER = (
     "pec", "geometry", "sphere", "network", "axis_status", "tool_change",
 )
 
-PAGE_RE = re.compile(r"^page\s+id=(\S+)\s+title=(.+?)\s*$")
+# Match both regular pages and A4 dialog records — `ui_page <id>` in the
+# kernel CLI now routes dialogs through show_dialog, which paints the
+# modal over whatever page is currently active (the previous capture in
+# PAGE_ORDER, naturally). Capturing dialogs as their own entries means
+# UI.md still gets a screenshot of each one and visual regressions in
+# dialog rendering are caught alongside page regressions.
+PAGE_RE = re.compile(r"^(?:page|dialog)\s+id=(\S+)\s+title=(.+?)\s*$")
 
 def load_pages(tsv_path):
     found = {}

--- a/ui/fb.cpp
+++ b/ui/fb.cpp
@@ -300,6 +300,44 @@ void Framebuffer::fill_rect(int32_t x, int32_t y, uint32_t w, uint32_t h, Color 
     mark_dirty_rect(x, y, w, h);
 }
 
+void Framebuffer::fill_rect_alpha(int32_t x, int32_t y, uint32_t w, uint32_t h, Color c) {
+    // Fast paths: fully opaque → solid fill; fully transparent → no-op.
+    if (c.a == 255) { fill_rect(x, y, w, h, c); return; }
+    if (c.a == 0)   return;
+    if (x < 0) { if ((uint32_t)(-x) >= w) return; w -= (-x); x = 0; }
+    if (y < 0) { if ((uint32_t)(-y) >= h) return; h -= (-y); y = 0; }
+    if (static_cast<uint32_t>(x) >= FB_WIDTH || static_cast<uint32_t>(y) >= FB_HEIGHT) return;
+    const uint32_t max_w = FB_WIDTH - static_cast<uint32_t>(x);
+    const uint32_t max_h = FB_HEIGHT - static_cast<uint32_t>(y);
+    if (w > max_w) w = max_w;
+    if (h > max_h) h = max_h;
+    if (w == 0 || h == 0) return;
+
+    // src-over Porter–Duff. Output alpha is forced to 255 (the framebuffer
+    // is treated as opaque from the scanout's POV — virtio-gpu draws it
+    // straight to screen).
+    const uint16_t a     = c.a;
+    const uint16_t inv_a = 255 - a;
+    const uint16_t r_pre = static_cast<uint16_t>(c.r) * a;
+    const uint16_t g_pre = static_cast<uint16_t>(c.g) * a;
+    const uint16_t b_pre = static_cast<uint16_t>(c.b) * a;
+    for (uint32_t row = 0; row < h; ++row) {
+        uint32_t* row_ptr = &buffer_[(y + row) * FB_WIDTH + x];
+        for (uint32_t col = 0; col < w; ++col) {
+            const uint32_t bg = row_ptr[col];
+            const uint16_t bgr = (bg >> 16) & 0xFFu;
+            const uint16_t bgg = (bg >>  8) & 0xFFu;
+            const uint16_t bgb = (bg      ) & 0xFFu;
+            const uint8_t outr = static_cast<uint8_t>((r_pre + bgr * inv_a) / 255);
+            const uint8_t outg = static_cast<uint8_t>((g_pre + bgg * inv_a) / 255);
+            const uint8_t outb = static_cast<uint8_t>((b_pre + bgb * inv_a) / 255);
+            row_ptr[col] = (0xFFu << 24) | (static_cast<uint32_t>(outr) << 16) |
+                           (static_cast<uint32_t>(outg) << 8) | static_cast<uint32_t>(outb);
+        }
+    }
+    mark_dirty_rect(x, y, w, h);
+}
+
 void Framebuffer::draw_rect(int32_t x, int32_t y, uint32_t w, uint32_t h, Color c, uint32_t line_width) {
     // Top
     fill_rect(x, y, w, line_width, c);

--- a/ui/fb.hpp
+++ b/ui/fb.hpp
@@ -71,6 +71,13 @@ public:
     
     // Draw filled rectangle
     void fill_rect(int32_t x, int32_t y, uint32_t w, uint32_t h, Color c);
+
+    // Alpha-blended filled rectangle. Reads each destination pixel,
+    // src-over blends with the source colour (using `c.a` as opacity),
+    // writes back. Used by the dialog backdrop to darken the page
+    // underneath without losing it visually. Identical to fill_rect when
+    // c.a == 255; no-op when c.a == 0.
+    void fill_rect_alpha(int32_t x, int32_t y, uint32_t w, uint32_t h, Color c);
     
     // Draw outline rectangle
     void draw_rect(int32_t x, int32_t y, uint32_t w, uint32_t h, Color c, uint32_t line_width = 1);

--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -46,6 +46,7 @@ constexpr uint32_t MAX_LAYOUT_CHILDREN = 32;
 enum class RecordType : uint8_t {
     Unknown = 0,
     Page,
+    Dialog,    // A4: Z-layer above pages; same parse shape as Page.
     Include,
     Child,
     Action,
@@ -71,6 +72,13 @@ struct PageSpec {
     uint32_t first_widget = 0;
     uint32_t widget_count = 0;
     Widget* root = nullptr;
+    // A4: dialog Z-layer. Pages declared as `dialog id=foo` get is_dialog
+    // = true. Dialogs are hidden by default, shown via show_dialog() or
+    // `action target=dialog:show:foo`, and render *above* the active
+    // page (Container::render iterates in TSV-add order; dialogs are
+    // declared after pages so they render last). set_active_page skips
+    // dialogs so they never appear via goto: navigation.
+    bool is_dialog = false;
 };
 
 struct ChildSpec {
@@ -294,6 +302,7 @@ BuilderEvent parse_event(const char* s) {
 RecordType parse_record_type(const char* s) {
     if (!s) return RecordType::Unknown;
     if (strcmp(s, "page") == 0) return RecordType::Page;
+    if (strcmp(s, "dialog") == 0) return RecordType::Dialog;
     if (strcmp(s, "include") == 0) return RecordType::Include;
     if (strcmp(s, "child") == 0) return RecordType::Child;
     if (strcmp(s, "action") == 0) return RecordType::Action;
@@ -2498,10 +2507,19 @@ bool validate_actions(uint32_t line_no) {
 
 void set_active_page(int idx) {
     if (idx < 0 || static_cast<uint32_t>(idx) >= g_page_count) return;
+    // Dialogs are toggled through show_dialog/hide_dialog only — never via
+    // page navigation. Rejecting here prevents an accidental
+    // `goto:<dialog_id>` from teleporting the operator into a modal with
+    // no way out.
+    if (g_pages[idx].is_dialog) return;
     kernel::core::ScopedLock guard(g_state_lock);
     g_active_page = idx;
     for (uint32_t i = 0; i < g_page_count; ++i) {
         if (!g_pages[i].root) continue;
+        if (g_pages[i].is_dialog) {
+            // Dialogs keep their own visibility (managed by show_dialog).
+            continue;
+        }
         if (static_cast<int>(i) == g_active_page) g_pages[i].root->show();
         else g_pages[i].root->hide();
     }
@@ -2513,6 +2531,15 @@ void set_active_page(int idx) {
     }
     if (g_root_widget) g_root_widget->mark_subtree_dirty();
 }
+
+// A4: dialog Z-layer state. Only one dialog is active at a time; calling
+// show_dialog with one already up replaces it. g_active_dialog == -1 when
+// no dialog is showing. The state lives inside the anonymous namespace
+// for TU-locality; the corresponding API entry points
+// (show_dialog/hide_dialog/active_dialog_*) are defined at ui_builder
+// namespace scope just below this anon block so the header declarations
+// resolve unambiguously.
+static int g_active_dialog = -1;
 
 void set_focus_widget(Widget* widget) {
     if (!widget) return;
@@ -2556,6 +2583,17 @@ void run_action_target(const char* target) {
     trace_click_delivery("[ui-click] action target=%s\n", target);
     if (strncmp(target, "goto:", 5) == 0) {
         set_active_page(find_page_index_by_id(target + 5));
+        return;
+    }
+    // A4: dialog Z-layer action targets.
+    //   dialog:show:<id>  → show dialog `id` over the current page
+    //   dialog:close      → hide whichever dialog is active
+    if (strncmp(target, "dialog:show:", 12) == 0) {
+        show_dialog(target + 12);
+        return;
+    }
+    if (strcmp(target, "dialog:close") == 0) {
+        hide_dialog();
         return;
     }
     if (strncmp(target, "page:", 5) == 0) {
@@ -4275,7 +4313,67 @@ class BuilderRoot final : public Container {
 public:
     BuilderRoot() : Container(0, 0, kernel::ui::FB_WIDTH, kernel::ui::FB_HEIGHT) {}
 
+    // A4: dialog Z-layer rendering. Override the default Container fan-out
+    // so that:
+    //   - When no dialog is active, pages render as usual (Container::render).
+    //   - When a dialog is active, render any pending page redraws once
+    //     (so the backdrop blends in their final state), paint a single
+    //     translucent dim layer over the whole FB, then render the dialog.
+    //   - Subsequent ticks while the dialog is up render *only* the dialog
+    //     root. Page widgets keep their dirty flags but stay un-drawn
+    //     under the backdrop. hide_dialog mark_subtree_dirty's the whole
+    //     tree so they all redraw fresh on dialog close.
+    void render(Framebuffer& fb) override {
+        if (g_active_dialog < 0) {
+            Container::render(fb);
+            last_rendered_dialog_ = -1;
+            return;
+        }
+        if (static_cast<uint32_t>(g_active_dialog) >= g_page_count) return;
+        if (last_rendered_dialog_ != g_active_dialog) {
+            // Dialog just shown. Drain any pending page redraws first so
+            // the backdrop dims their settled state.
+            Widget* dialog_root = g_pages[g_active_dialog].root;
+            for (size_t i = 0; i < child_count_; ++i) {
+                Widget* child = children_[i];
+                if (!child || child == dialog_root) continue;
+                if (!child->visible() || !child->needs_redraw()) continue;
+                child->render(fb);
+                child->clear_redraw();
+            }
+            // Translucent slate-900 with ~75 % opacity. Tuned so the page
+            // underneath stays readable but the dialog clearly owns focus.
+            fb.fill_rect_alpha(0, 0, kernel::ui::FB_WIDTH, kernel::ui::FB_HEIGHT,
+                               Color(0x0F, 0x17, 0x2A, 0xC0));
+            // Backdrop just covered everything below the dialog — force a
+            // full redraw of the dialog body against the dimmed pixels.
+            if (dialog_root) dialog_root->mark_subtree_dirty();
+            last_rendered_dialog_ = g_active_dialog;
+        }
+        Widget* dialog_root = g_pages[g_active_dialog].root;
+        if (dialog_root && dialog_root->visible() && dialog_root->needs_redraw()) {
+            dialog_root->render(fb);
+            dialog_root->clear_redraw();
+        }
+    }
+
     bool on_event(const UIEvent& event) override {
+        // Dialog active: dispatch to the dialog root first; if it doesn't
+        // handle the event, stop (don't fall through to page widgets).
+        // Modal semantics.
+        if (g_active_dialog >= 0 && static_cast<uint32_t>(g_active_dialog) < g_page_count) {
+            Widget* dialog_root = g_pages[g_active_dialog].root;
+            if (dialog_root && dialog_root->visible()) {
+                (void)dialog_root->on_event(event);
+                // Swallow touch events that fell outside the dialog body
+                // so they can't bubble to a page button underneath.
+                if (event.type == kernel::ui::EventType::TouchDown ||
+                    event.type == kernel::ui::EventType::TouchUp ||
+                    event.type == kernel::ui::EventType::TouchMove) {
+                    return true;
+                }
+            }
+        }
         if (event.type == kernel::ui::EventType::KeyDown) {
             if (event.key.keycode == '\t' || event.key.keycode == 0x1004U) {
                 advance_focus(1);
@@ -4303,6 +4401,13 @@ public:
         }
         return Container::on_event(event);
     }
+
+private:
+    // Tracks which dialog (if any) was painted on the last render call.
+    // Mismatch with g_active_dialog signals a transition — the backdrop
+    // gets painted exactly once on the show edge and the dialog body is
+    // forced to repaint against the new dimmed pixels.
+    int last_rendered_dialog_ = -1;
 };
 
 Widget* create_widget(const WidgetSpec& spec) {
@@ -4413,6 +4518,46 @@ void reset_state() {
 }
 
 } // namespace
+
+// A4: dialog Z-layer API. Definitions live at ui_builder namespace scope
+// (matching the header declarations) so external callers — and set_page
+// below — can call them unambiguously. They still reach into the anon-
+// namespace state (g_active_dialog, g_pages, g_state_lock) via the
+// enclosing-namespace promotion that the anon block provides.
+int active_dialog_index() { return g_active_dialog; }
+
+const char* active_dialog_id() {
+    if (g_active_dialog < 0 || static_cast<uint32_t>(g_active_dialog) >= g_page_count) return "";
+    return g_pages[g_active_dialog].id;
+}
+
+void show_dialog(const char* id) {
+    if (!id || !*id) return;
+    int idx = find_page_index_by_id(id);
+    if (idx < 0 || !g_pages[idx].is_dialog) return;
+    kernel::core::ScopedLock guard(g_state_lock);
+    // Hide any other dialog that might still be shown (defensive — caller
+    // shouldn't normally stack).
+    for (uint32_t i = 0; i < g_page_count; ++i) {
+        if (g_pages[i].is_dialog && g_pages[i].root && static_cast<int>(i) != idx) {
+            g_pages[i].root->hide();
+        }
+    }
+    g_active_dialog = idx;
+    if (g_pages[idx].root) g_pages[idx].root->show();
+    if (g_root_widget) g_root_widget->mark_subtree_dirty();
+}
+
+void hide_dialog() {
+    kernel::core::ScopedLock guard(g_state_lock);
+    if (g_active_dialog >= 0 && static_cast<uint32_t>(g_active_dialog) < g_page_count) {
+        if (g_pages[g_active_dialog].root) g_pages[g_active_dialog].root->hide();
+    }
+    g_active_dialog = -1;
+    // The backdrop covered every widget below it — force a full repaint of
+    // the page that re-emerges underneath.
+    if (g_root_widget) g_root_widget->mark_subtree_dirty();
+}
 
 WidgetSpec parse_widget(const char* record, size_t len) {
     WidgetSpec spec{};
@@ -4530,7 +4675,7 @@ bool load_tsv(const char* buf, size_t len) {
             set_error(line_no, "unknown record type");
             return false;
         }
-        if (record_type == RecordType::Page) {
+        if (record_type == RecordType::Page || record_type == RecordType::Dialog) {
             if (g_page_count >= MAX_PAGES) {
                 set_error(line_no, "page limit exceeded");
                 return false;
@@ -4538,6 +4683,7 @@ bool load_tsv(const char* buf, size_t len) {
             PageSpec& page = g_pages[g_page_count];
             page.first_widget = g_widget_count;
             page.widget_count = 0;
+            page.is_dialog = (record_type == RecordType::Dialog);
             KeyValueField fields[8]{};
             const uint32_t field_count = parse_fields(line, line_len, fields, 8);
             if (const char* id = field_value(fields, field_count, "id")) {
@@ -4664,7 +4810,24 @@ bool load_tsv(const char* buf, size_t len) {
         if (g_pages[i].root) root.add_child(g_pages[i].root);
     }
 
-    if (g_page_count > 0) set_active_page(0);
+    // A4: hide every dialog root at boot. set_active_page leaves dialog
+    // visibility alone (so a runtime show_dialog isn't undone by a peer
+    // page switch), which means initial visibility must be set explicitly.
+    for (uint32_t i = 0; i < g_page_count; ++i) {
+        if (g_pages[i].is_dialog && g_pages[i].root) g_pages[i].root->hide();
+    }
+    g_active_dialog = -1;
+
+    // First regular (non-dialog) page becomes the active page. If the TSV
+    // starts with a dialog definition the loop falls through to find the
+    // first page.
+    if (g_page_count > 0) {
+        int first_page = -1;
+        for (uint32_t i = 0; i < g_page_count; ++i) {
+            if (!g_pages[i].is_dialog) { first_page = static_cast<int>(i); break; }
+        }
+        if (first_page >= 0) set_active_page(first_page);
+    }
     return g_root_widget != nullptr;
 }
 
@@ -4675,7 +4838,18 @@ Widget* root_widget() {
 bool set_page(const char* page_id) {
     const int idx = find_page_index_by_id(page_id);
     if (idx < 0) return false;
-    set_active_page(idx);
+    // CLI `ui_page <id>` accepts dialogs too — useful for screenshot
+    // capture and for kernel-side testing. Regular pages route through
+    // set_active_page; dialogs route through show_dialog so the modal
+    // semantics (backdrop, page underneath frozen) still apply.
+    if (g_pages[idx].is_dialog) {
+        show_dialog(g_pages[idx].id);
+    } else {
+        // Closing any open dialog when navigating to a regular page keeps
+        // the operator out of stuck-modal states from CLI navigation.
+        if (g_active_dialog >= 0) hide_dialog();
+        set_active_page(idx);
+    }
     return true;
 }
 

--- a/ui/ui_builder_tsv.hpp
+++ b/ui/ui_builder_tsv.hpp
@@ -158,6 +158,20 @@ void tick();
 void lock_state() noexcept;
 void unlock_state() noexcept;
 
+// A4: dialog Z-layer API. Dialogs are declared in the TSV via `dialog
+// id=foo title=...` (same shape as `page`) and behave as a modal layer
+// above the active page. show_dialog(id) makes the dialog visible and
+// causes BuilderRoot::render to paint a translucent backdrop over the
+// page underneath; hide_dialog() removes the dialog and triggers a
+// page re-render. Action targets `dialog:show:<id>` and `dialog:close`
+// route through the same API. set_active_page refuses to switch into
+// a dialog so an accidental `goto:<dialog_id>` can't trap the
+// operator in a modal with no exit.
+void show_dialog(const char* id);
+void hide_dialog();
+int  active_dialog_index();
+const char* active_dialog_id();
+
 }
 
 #endif // UI_BUILDER_TSV_HPP


### PR DESCRIPTION
Closes the last item of Phase A. Adds a modal Z-layer above the page tree so confirm / wizard / restart flows can surface without obliterating the operator's prior context.

## What lands

- **TSV schema:** new `dialog id=foo title=...` record (same parse shape as `page`); new action targets `dialog:show:<id>` and `dialog:close`.
- **Runtime:** `ui_builder::show_dialog(id)`, `hide_dialog()`, `active_dialog_index()`, `active_dialog_id()` exposed in `ui_builder_tsv.hpp`. `set_active_page` refuses to switch into a dialog so accidental `goto:<dialog_id>` can't trap the operator. CLI `ui_page <id>` routes dialogs through `show_dialog` automatically so screenshot capture handles them too.
- **`BuilderRoot::render` override:** on transition into a dialog, drain any pending page redraws, paint a translucent slate-900 (`#0F172AC0`) backdrop via the new `fb.fill_rect_alpha`, then render the dialog body. Subsequent ticks render only the dialog root — page widgets keep their dirty flags but don't paint under the dim. `hide_dialog` mark_subtree_dirty's the tree so pages redraw fresh on close.
- **`BuilderRoot::on_event` override:** when a dialog is active, dispatch touches to the dialog root first and swallow misses (modal semantics — page buttons underneath shouldn't accept clicks through the backdrop).
- **`Framebuffer::fill_rect_alpha`:** src-over Porter–Duff blend with fast paths for `c.a == 0` (no-op) and `c.a == 255` (delegate to `fill_rect`). Output alpha forced to 255 (the FB is opaque to the scanout).
- **TSV:** `restart_confirm` converted from `page` to `dialog`. Shrunk to a 960 × 1400 centred panel, CANCEL button rewired to `dialog:close`, `bottom_nav` include removed (dialogs don't navigate).
- **Capture script:** `PAGE_RE` now matches both `page` and `dialog`. UI.md gets a frame of each dialog overlaid on its prior page context.

## Verification

- `make TARGET=arm64` clean
- Boot smoke: CLI ready, echo, `[ec0] cycle=250us`, no PANIC / `[exc] unhandled`
- All 20 UI screenshots capture clean
- `restart_confirm` capture: dominant colour 25.6 %, 19 distinct colours — visually the modal sits over the prior-captured `sphere` page through the dim backdrop, exactly as designed.

## What's next

Phase A is done. Up next: Phase B (authoring DX — generated bind catalogue, TSV templates, layout helpers, lint). Each phase ships as its own PR.

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_