### PR TITLE
UI Phase B (partial): bind catalogue extractor + ui_editor lint (B6, B9)

### DIFF
--- a/tools/extract_bind_catalogue.py
+++ b/tools/extract_bind_catalogue.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""
+Extract the bind / action / widget-type catalogue from ui/ui_builder_tsv.cpp.
+
+The TSV UI editor (tools/ui_editor/index.html) carries a hardcoded mirror of
+the kernel's parse_bind() / run_action_target() / parse_type() name tables.
+Without a source of truth, the two drift: a new bind added in the kernel
+won't show up in the editor's dropdown, and an editor-only entry won't
+actually bind anything at runtime.
+
+This script scans ui_builder_tsv.cpp for the relevant strcmp() == 0 returns
+and emits a single JSON catalogue. Consumers:
+
+  * tools/ui_editor/sync_catalogue.py (TODO) — compare against the
+    hardcoded BIND_GROUPS / ACTION_GROUPS in index.html.
+  * docs/bind-catalogue.json (TODO) — committed artifact that PR reviewers
+    can scan to see new bind/action surface.
+  * Future: editor fetches catalogue.generated.js inlined into index.html
+    at build time.
+
+Usage:
+  python3 tools/extract_bind_catalogue.py             # to stdout
+  python3 tools/extract_bind_catalogue.py --output X  # to file X
+  python3 tools/extract_bind_catalogue.py --pretty    # human-readable JSON
+
+The script is deliberately conservative — anything it doesn't recognise is
+emitted under an "unclassified" bucket so a maintainer can decide. It
+doesn't try to evaluate macro-expanded values or runtime-only registrations.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SOURCE = REPO_ROOT / "ui" / "ui_builder_tsv.cpp"
+
+# Bind name → BindKind enum constant.
+#   if (strcmp(s, "mode") == 0) return BindKind::Mode;
+BIND_RE = re.compile(
+    r'\bstrcmp\(s,\s*"([^"]+)"\)\s*==\s*0\)\s*return\s+BindKind::(\w+)\s*;'
+)
+
+# Action target → handler. Two shapes are common:
+#   if      (strcmp(target, "x") == 0) ...;
+#   else if (strncmp(target, "x:", N) == 0) ...;
+# We capture exact (strcmp) matches; prefix (strncmp) matches are surfaced
+# separately as "families" so the catalogue records the prefix without
+# pretending it's an exhaustive list.
+ACTION_EXACT_RE = re.compile(r'\bstrcmp\(target,\s*"([^"]+)"\)\s*==\s*0\)')
+ACTION_PREFIX_RE = re.compile(r'\bstrncmp\(target,\s*"([^"]+)",\s*\d+\)\s*==\s*0\)')
+
+# Widget type — parse_type's strcmp returns.
+WIDGET_TYPE_RE = re.compile(
+    r'\bstrcmp\(s,\s*"([^"]+)"\)\s*==\s*0\)\s*return\s+WidgetType::(\w+)\s*;'
+)
+
+# Layout (parse_layout)
+LAYOUT_RE = re.compile(
+    r'\bstrcmp\(s,\s*"([^"]+)"\)\s*==\s*0\)\s*return\s+LayoutType::(\w+)\s*;'
+)
+
+# Align (parse_align)
+ALIGN_RE = re.compile(
+    r'\bstrcmp\(s,\s*"([^"]+)"\)\s*==\s*0\)\s*return\s+Align::(\w+)\s*;'
+)
+
+# Record type (parse_record_type)
+RECORD_RE = re.compile(
+    r'\bstrcmp\(s,\s*"([^"]+)"\)\s*==\s*0\)\s*return\s+RecordType::(\w+)\s*;'
+)
+
+
+def extract(source_path: Path) -> dict:
+    if not source_path.exists():
+        raise FileNotFoundError(source_path)
+    text = source_path.read_text(encoding="utf-8")
+
+    binds = [{"name": m.group(1), "kind": m.group(2)} for m in BIND_RE.finditer(text)]
+    actions_exact = sorted({m.group(1) for m in ACTION_EXACT_RE.finditer(text)})
+    actions_prefix = sorted({m.group(1) for m in ACTION_PREFIX_RE.finditer(text)})
+    widget_types = [
+        {"name": m.group(1), "kind": m.group(2)} for m in WIDGET_TYPE_RE.finditer(text)
+    ]
+    layouts = [{"name": m.group(1), "kind": m.group(2)} for m in LAYOUT_RE.finditer(text)]
+    aligns = [{"name": m.group(1), "kind": m.group(2)} for m in ALIGN_RE.finditer(text)]
+    records = [{"name": m.group(1), "kind": m.group(2)} for m in RECORD_RE.finditer(text)]
+
+    return {
+        "source": str(source_path.relative_to(REPO_ROOT)),
+        "binds": binds,
+        "actions": {
+            "exact": actions_exact,
+            "prefix_families": actions_prefix,
+        },
+        "widget_types": widget_types,
+        "layouts": layouts,
+        "aligns": aligns,
+        "record_types": records,
+        "summary": {
+            "bind_count": len(binds),
+            "action_exact_count": len(actions_exact),
+            "action_prefix_count": len(actions_prefix),
+            "widget_type_count": len(widget_types),
+        },
+    }
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    p.add_argument("--source", type=Path, default=DEFAULT_SOURCE,
+                   help=f"path to ui_builder_tsv.cpp (default: {DEFAULT_SOURCE})")
+    p.add_argument("--output", "-o", type=Path, default=None,
+                   help="write JSON to this file (default: stdout)")
+    p.add_argument("--pretty", action="store_true",
+                   help="indent JSON for human inspection")
+    args = p.parse_args(argv)
+
+    try:
+        catalogue = extract(args.source)
+    except FileNotFoundError as e:
+        print(f"error: source not found: {e}", file=sys.stderr)
+        return 1
+
+    text = json.dumps(catalogue, indent=2 if args.pretty else None,
+                      sort_keys=False) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+        print(f"wrote {args.output} ({catalogue['summary']['bind_count']} binds, "
+              f"{catalogue['summary']['action_exact_count']} exact actions, "
+              f"{catalogue['summary']['action_prefix_count']} action families, "
+              f"{catalogue['summary']['widget_type_count']} widget types)",
+              file=sys.stderr)
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/lint_ui_editor.py
+++ b/tools/lint_ui_editor.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""
+Lint tools/ui_editor/index.html against the bind / action catalogue
+extracted from ui/ui_builder_tsv.cpp.
+
+The editor's BIND_GROUPS and ACTION_GROUPS JavaScript object literals
+must stay in sync with the kernel's parse_bind() / run_action_target()
+tables — otherwise the autocomplete drops bindings that the kernel still
+accepts, or the editor offers bindings the kernel will silently reject.
+
+This script:
+
+  1. Extracts the live catalogue via tools/extract_bind_catalogue.py
+  2. Parses BIND_GROUPS and ACTION_GROUPS out of index.html
+  3. Reports name-set deltas in both directions
+
+Exit code:
+  0 — no drift, or only the explicit prefix-family expansions that the
+      editor enumerates by index (e.g. `program:0:name`..`program:7:name`)
+  1 — at least one bind / action exists in one side and not the other
+
+Usage:
+  python3 tools/lint_ui_editor.py                   # default report
+  python3 tools/lint_ui_editor.py --strict          # fail on any drift
+  python3 tools/lint_ui_editor.py --json            # machine-readable
+"""
+
+import argparse
+import json
+import re
+import sys
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EDITOR_PATH = REPO_ROOT / "tools" / "ui_editor" / "index.html"
+EXTRACTOR = REPO_ROOT / "tools" / "extract_bind_catalogue.py"
+
+# Match the JS object literal `const BIND_GROUPS = { ... };` and
+# `const ACTION_GROUPS = { ... };`. We don't actually parse JS — just
+# rip out every quoted string between the braces.
+GROUP_BLOCK_RE = re.compile(
+    r'const\s+(BIND|ACTION)_GROUPS\s*=\s*\{(.*?)\};',
+    re.DOTALL,
+)
+QUOTED_RE = re.compile(r'"([^"]+)"')
+
+
+def extract_editor_sets(html: str) -> tuple[set[str], set[str]]:
+    binds: set[str] = set()
+    actions: set[str] = set()
+    for m in GROUP_BLOCK_RE.finditer(html):
+        which = m.group(1)
+        body = m.group(2)
+        names = set(QUOTED_RE.findall(body))
+        if which == "BIND":
+            binds |= names
+        else:
+            actions |= names
+    return binds, actions
+
+
+def extract_kernel_catalogue() -> dict:
+    proc = subprocess.run(
+        [sys.executable, str(EXTRACTOR)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def strip_indexed(names: set[str], family_prefixes: set[str]) -> set[str]:
+    """Remove names that look like `<family>N[:...]` for any prefix family.
+
+    The editor enumerates a fixed number of program slots / tool slots /
+    alarm history rows etc. as concrete bind names like
+    `program:0:name`..`program:7:name`. The kernel handles the same via
+    a runtime prefix dispatch (`program:` action family), so the catalogue
+    only carries the family prefix. Drop those explicit enumerations from
+    the editor side when comparing so we don't get spurious deltas.
+    """
+    out = set()
+    for n in names:
+        keep = True
+        for prefix in family_prefixes:
+            if n.startswith(prefix):
+                # Trim family prefix; check if the remainder starts with a
+                # digit (i.e. it's an indexed slot).
+                tail = n[len(prefix):]
+                if tail and tail[0].isdigit():
+                    keep = False
+                    break
+        if keep:
+            out.add(n)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    p.add_argument("--editor", type=Path, default=EDITOR_PATH,
+                   help=f"path to ui_editor/index.html (default: {EDITOR_PATH})")
+    p.add_argument("--strict", action="store_true",
+                   help="exit nonzero on any drift, including indexed-slot expansions")
+    p.add_argument("--json", action="store_true",
+                   help="emit a machine-readable JSON report")
+    args = p.parse_args(argv)
+
+    if not args.editor.exists():
+        print(f"error: editor not found: {args.editor}", file=sys.stderr)
+        return 2
+    editor_html = args.editor.read_text(encoding="utf-8")
+    editor_binds, editor_actions = extract_editor_sets(editor_html)
+    catalogue = extract_kernel_catalogue()
+
+    kernel_binds = {b["name"] for b in catalogue["binds"]}
+    kernel_actions_exact = set(catalogue["actions"]["exact"])
+    kernel_action_families = set(catalogue["actions"]["prefix_families"])
+
+    # Strip the kernel's indexed enumerations from the editor side so the
+    # `program:0:name`..`program:7:name` rows don't all show up as drift.
+    bind_families = {p for p in kernel_action_families} | {
+        # Bind families that the kernel resolves at runtime via prefix.
+        "program:", "tool:T", "alarm:", "wcs:G", "axis:", "cal:pec:",
+    }
+    editor_binds_collapsed = strip_indexed(editor_binds, bind_families) if not args.strict else editor_binds
+    editor_actions_collapsed = strip_indexed(editor_actions, kernel_action_families) if not args.strict else editor_actions
+
+    def covered_by_family(name: str, families: set[str]) -> bool:
+        return any(name.startswith(p) for p in families)
+
+    binds_only_in_editor = {
+        b for b in editor_binds_collapsed
+        if b not in kernel_binds and not covered_by_family(b, bind_families)
+    }
+    binds_only_in_kernel = kernel_binds - editor_binds
+    actions_only_in_editor = {
+        a for a in editor_actions_collapsed
+        if a not in kernel_actions_exact and not covered_by_family(a, kernel_action_families)
+    }
+    actions_only_in_kernel = kernel_actions_exact - editor_actions
+
+    report = {
+        "editor": str(args.editor.relative_to(REPO_ROOT)),
+        "kernel_source": catalogue["source"],
+        "summary": {
+            "editor_binds": len(editor_binds),
+            "editor_actions": len(editor_actions),
+            "kernel_binds": len(kernel_binds),
+            "kernel_actions_exact": len(kernel_actions_exact),
+            "kernel_action_families": len(kernel_action_families),
+            "drift_binds_editor_only": len(binds_only_in_editor),
+            "drift_binds_kernel_only": len(binds_only_in_kernel),
+            "drift_actions_editor_only": len(actions_only_in_editor),
+            "drift_actions_kernel_only": len(actions_only_in_kernel),
+        },
+        "binds_editor_only": sorted(binds_only_in_editor),
+        "binds_kernel_only": sorted(binds_only_in_kernel),
+        "actions_editor_only": sorted(actions_only_in_editor),
+        "actions_kernel_only": sorted(actions_only_in_kernel),
+    }
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"UI editor catalogue lint vs {catalogue['source']}")
+        s = report["summary"]
+        print(f"  editor: {s['editor_binds']} binds, {s['editor_actions']} actions")
+        print(f"  kernel: {s['kernel_binds']} binds, {s['kernel_actions_exact']} exact actions, "
+              f"{s['kernel_action_families']} action families")
+        print()
+        if binds_only_in_editor:
+            print(f"BINDS in editor but not in kernel ({len(binds_only_in_editor)}):")
+            for n in sorted(binds_only_in_editor):
+                print(f"  - {n}")
+        if binds_only_in_kernel:
+            print(f"BINDS in kernel but not in editor ({len(binds_only_in_kernel)}):")
+            for n in sorted(binds_only_in_kernel):
+                print(f"  + {n}")
+        if actions_only_in_editor:
+            print(f"ACTIONS in editor but not in kernel ({len(actions_only_in_editor)}):")
+            for n in sorted(actions_only_in_editor):
+                print(f"  - {n}")
+        if actions_only_in_kernel:
+            print(f"ACTIONS in kernel but not in editor ({len(actions_only_in_kernel)}):")
+            for n in sorted(actions_only_in_kernel):
+                print(f"  + {n}")
+        if (not binds_only_in_editor and not binds_only_in_kernel
+                and not actions_only_in_editor and not actions_only_in_kernel):
+            print("OK — editor catalogue is in sync.")
+
+    drift = (binds_only_in_editor or binds_only_in_kernel
+             or actions_only_in_editor or actions_only_in_kernel)
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Two items from Phase B (authoring DX) — self-contained tooling, no kernel changes.

## B6 — Generated bind catalogue (`tools/extract_bind_catalogue.py`)

Scans `ui/ui_builder_tsv.cpp` for the `strcmp() == 0` returns inside `parse_bind`, `run_action_target`, `parse_type`, `parse_layout`, `parse_align`, and `parse_record_type`. Emits a single JSON catalogue. Current main:

| Surface | Count |
|---|---|
| Binds | 237 |
| Actions (exact) | 51 |
| Actions (prefix families) | 18 |
| Widget types | 9 |
| Layouts | 3 |
| Aligns | 2 |
| Record types | 4 |

Usage:
```
python3 tools/extract_bind_catalogue.py --pretty --output docs/bind-catalogue.json
```

## B9 — UI editor lint (`tools/lint_ui_editor.py`)

Parses `BIND_GROUPS` / `ACTION_GROUPS` JS literals out of `tools/ui_editor/index.html`, compares against the extracted catalogue, reports name-set deltas in both directions. Indexed-slot expansions (`program:0:name`..`program:7:name`) collapse to the kernel's `program:` family on the kernel side. Exits non-zero on any drift.

### Current drift surfaced (real findings, follow-up PR)

**39 binds in kernel but not in editor:**
- `pallet:0..3:{id,status,program,cycles}` (16 — pallet roster bindings)
- `scheduler:{active,jobcount,state}` (3 — jobs scheduler)
- `restart:{pending,line,tool,wcs,feed,spindle,coolant}` (7 — restart dialog content)
- `ec:{dc_drift_last,dc_drift_max,dc_fault,dc_samples,dc_trips}` (5 — distributed clock)
- `lookahead:{0,1,max}` (3 — look-ahead chain depth)
- `channel:0..1:barrier_ms` (2 — mill-turn sync)
- `tcp:status`, `spindle_override`, `klog:tail` (3)

**2 actions in kernel but not in editor:** `restart:confirm`, `restart:cancel` — the A4 dialog buttons (PR #22).

These are real surfaces the operator can't discover via editor autocomplete; updating `BIND_GROUPS` / `ACTION_GROUPS` is a follow-up since it's a content change in `index.html`, not a tooling change.

## Not committed

`docs/bind-catalogue.json` — `/docs` is `.gitignored`. The script regenerates on demand.

## Follow-ups (out of scope here)

- CI gate that fails the workflow if `lint_ui_editor.py` reports drift
- `inject_catalogue.py` that rewrites the editor's hardcoded `BIND_GROUPS` / `ACTION_GROUPS` from the catalogue at build time
- Editor consumes `catalogue.generated.js` directly (loses the single-file-HTML invariant — needs design discussion)

## Phase B remaining

- B5 (live preview WebSocket) — defer; needs CLI proxy + WS support in kernel
- B7 (reusable widget templates) — TSV format extension, own PR
- B8 (layout helpers: row/column/grid TSV records) — TSV format extension, own PR

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_