### PR TITLE
UI B8: TSV layout overrides — cols/rows/spacing/pad on Container/Panel

### DIFF
--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -4447,8 +4447,11 @@ void apply_layout(int parent_idx) {
     }
     if (bucket.count == 0) return;
 
-    const int32_t pad = 16;
-    const int32_t gap = 12;
+    // B8: per-container layout overrides. pad/gap default to the original
+    // 16/12 px if the TSV doesn't set them; passing `pad=0` is honoured so
+    // a container can pack flush against its bounds.
+    const int32_t pad = parent.spec.layout_pad >= 0 ? parent.spec.layout_pad : 16;
+    const int32_t gap = parent.spec.layout_gap > 0  ? parent.spec.layout_gap : 12;
     int32_t cursor_x = parent.spec.x + pad;
     int32_t cursor_y = parent.spec.y + pad + (parent.spec.type == WidgetType::Panel ? 24 : 0);
     const int32_t inner_w = parent.spec.w - pad * 2;
@@ -4480,10 +4483,21 @@ void apply_layout(int parent_idx) {
             cursor_x += child.w + gap;
         }
     } else if (parent.spec.layout == LayoutType::Grid) {
-        const int32_t cols = bucket.count > 1 ? 2 : 1;
-        const int32_t rows = static_cast<int32_t>((bucket.count + cols - 1) / cols);
+        // B8: honour `cols=N` / `rows=M` overrides. With neither set the
+        // historical default of "2 cols, rows derived" kicks in. With cols
+        // alone the row count is derived; with rows alone cols are derived;
+        // with both set the explicit grid is used (extra children spill
+        // outside the inner box, same as before).
+        int32_t cols = parent.spec.layout_cols > 0
+            ? parent.spec.layout_cols
+            : (bucket.count > 1 ? 2 : 1);
+        int32_t rows = parent.spec.layout_rows > 0
+            ? parent.spec.layout_rows
+            : static_cast<int32_t>((bucket.count + cols - 1) / cols);
+        if (cols <= 0) cols = 1;
+        if (rows <= 0) rows = 1;
         const int32_t cell_w = (inner_w - (cols - 1) * gap) / cols;
-        const int32_t cell_h = rows > 0 ? (inner_h - (rows - 1) * gap) / rows : inner_h;
+        const int32_t cell_h = (inner_h - (rows - 1) * gap) / rows;
         for (uint32_t i = 0; i < bucket.count; ++i) {
             WidgetSpec& child = g_widgets[bucket.children[i]].spec;
             const int32_t row = static_cast<int32_t>(i / cols);
@@ -4609,6 +4623,23 @@ WidgetSpec parse_widget(const char* record, size_t len) {
         }
         else if (strcmp(key_buf, "active_if") == 0) {
             copy_field(spec.active_if, sizeof(spec.active_if), val_buf, strlen(val_buf));
+        }
+        // B8: layout overrides on Container/Panel widgets.
+        else if (strcmp(key_buf, "cols") == 0) {
+            const int32_t n = simple_atoi(val_buf);
+            spec.layout_cols = n > 0 ? n : 0;
+        }
+        else if (strcmp(key_buf, "rows") == 0) {
+            const int32_t n = simple_atoi(val_buf);
+            spec.layout_rows = n > 0 ? n : 0;
+        }
+        else if (strcmp(key_buf, "spacing") == 0 || strcmp(key_buf, "gap") == 0) {
+            const int32_t n = simple_atoi(val_buf);
+            spec.layout_gap = n >= 0 ? n : 0;
+        }
+        else if (strcmp(key_buf, "pad") == 0) {
+            const int32_t n = simple_atoi(val_buf);
+            spec.layout_pad = n >= 0 ? n : -1;
         }
     }
     return spec;

--- a/ui/ui_builder_tsv.hpp
+++ b/ui/ui_builder_tsv.hpp
@@ -18,6 +18,10 @@
 //
 // Layout:
 //   panel/container ... layout=horizontal|vertical|grid
+//                       [cols=N rows=M]   (grid: override the 2×N default)
+//                       [spacing=N|gap=N] (override the 12 px inter-child gap)
+//                       [pad=N]           (override the 16 px inner padding;
+//                                          pad=0 packs children flush)
 //   child     parent=    widget=   align=left|center|right
 //
 // Events:
@@ -133,6 +137,17 @@ struct WidgetSpec {
     float max_val = 100;
     float value = 0;
     uint32_t text_scale = 1;  // Label + Button: integer pixel scale for draw_text_scaled
+
+    // B8: layout overrides for Container/Panel widgets that set layout=...
+    // 0 means "use the default" so existing TSV keeps working unchanged.
+    //   layout=grid    — cols default 2, rows derived from child count.
+    //                    Set `cols=N rows=M` to override.
+    //   layout=horizontal|vertical — `spacing=N` overrides the 12 px gap,
+    //                    `pad=N` overrides the 16 px inner padding.
+    int32_t layout_cols = 0;
+    int32_t layout_rows = 0;
+    int32_t layout_gap  = 0;
+    int32_t layout_pad  = -1;  // negative sentinel: keep the default 16
 };
 
 // Parse TSV record into WidgetSpec


### PR DESCRIPTION
Phase B item — closes B8 (layout helpers). The existing `layout=horizontal|vertical|grid` support in `apply_layout` was hardcoded: gap=12 px, pad=16 px, grid cols=2 always. Pages that wanted a 4-col grid or flush-packed rows had to hand-position every child.

New optional fields on Container / Panel widgets:

| Field | Effect | Default |
|---|---|---|
| `cols=N` | grid: explicit column count | 2 |
| `rows=N` | grid: explicit row count | derived from child count + cols |
| `spacing=N` (alias `gap=N`) | inter-child gap in px | 12 |
| `pad=N` | inner padding in px (`pad=0` packs flush against bounds) | 16 |

Defaults preserved — every existing TSV record keeps its current layout. Adding a field is purely opt-in.

```
panel id=wcs_grid x=20 y=200 w=1040 h=400 layout=grid cols=3 spacing=8 pad=12
label id=wcs_x parent=wcs_grid ...
label id=wcs_y parent=wcs_grid ...
...
```

Each child label gets its `x/y/w/h` auto-computed.

## Verification

- `make TARGET=arm64` clean
- Boot smoke: CLI ready, echo, `[ec0] cycle=250us`, no PANIC
- 20/20 UI screenshots capture cleanly (no visual regression — existing pages don't yet opt into the new fields)

## Deferred to follow-up

**B7 (widget templates with `${arg}` substitution)** — substantial parser extension. The `include page=<id>` mechanism that already clones bottom_nav into every page covers the simplest use case; templates with parameter substitution are higher value but bigger scope. Better as its own PR.

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_