### PR TITLE
UI E19: per-page screenshot diff in PR comment

### DIFF
--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -55,7 +55,8 @@ jobs:
             gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu \
             qemu-system-arm \
             ffmpeg \
-            python3
+            python3 \
+            python3-pil
 
       - name: Build arm64 kernel
         run: make TARGET=arm64
@@ -74,6 +75,29 @@ jobs:
         run: |
           python3 scripts/generate_ui_md.py screenshots UI.md
           head -40 UI.md
+
+      - name: Diff screenshots vs main baseline (E19)
+        # On PRs, compare each captured PNG against the committed
+        # baseline on main. Per-page pixel diff + bbox surface in the
+        # PR comment below. Skipped on push to main (the new commit IS
+        # the baseline). Tolerant: a missing baseline directory or PIL
+        # import error still lets the workflow continue.
+        if: github.event_name == 'pull_request'
+        run: |
+          # Pull main's committed screenshots/ into a temp dir without
+          # touching the working tree (the PR head already has its
+          # own screenshots/ from the capture step above).
+          mkdir -p /tmp/baseline_screenshots
+          if git show "origin/main:screenshots/" >/dev/null 2>&1; then
+              for f in $(git ls-tree -r --name-only origin/main -- screenshots/ | grep '\.png$'); do
+                  out="/tmp/baseline_screenshots/$(basename "$f")"
+                  git show "origin/main:$f" > "$out" 2>/dev/null || rm -f "$out"
+              done
+          fi
+          # Emit Markdown that the PR-comment step below picks up.
+          python3 scripts/screenshot_diff.py screenshots /tmp/baseline_screenshots \
+              > /tmp/screenshot_diff.md || true
+          cat /tmp/screenshot_diff.md
 
       - name: Upload artifacts
         # Run even when capture / regenerate failed so partial PNGs and the
@@ -134,6 +158,11 @@ jobs:
               printf -- '- 🪵 Workflow run: %s\n' "${JOB_URL}"
               if [ "$suspicious" -gt 0 ]; then
                   printf -- '- ⚠️ %s page(s) under 600 bytes — possible blank-fallback render. Pull the artifact zip to inspect.\n' "${suspicious}"
+              fi
+              # E19: per-page diff vs main baseline.
+              if [ -s /tmp/screenshot_diff.md ]; then
+                  printf '\n'
+                  cat /tmp/screenshot_diff.md
               fi
               printf '\n'
               printf '_Auto-posted by `.github/workflows/ui-screenshots.yml`. Comment updates on each push to this PR._\n'

--- a/scripts/screenshot_diff.py
+++ b/scripts/screenshot_diff.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""
+Per-page pixel diff between this PR's captured screenshots and the
+baseline committed on main.
+
+Usage:
+  python3 scripts/screenshot_diff.py <fresh_dir> <baseline_dir> [--json]
+
+Reads every <fresh_dir>/*.png, finds the matching name in <baseline_dir>,
+and runs a cheap pixel comparison (PIL ImageChops.difference + bbox).
+Emits a Markdown summary suitable for inclusion in a PR comment, or
+machine-readable JSON when --json is set.
+
+Why not ImageMagick `compare`?
+  - PIL is in the standard runner image; ImageMagick is one apt-get away
+    but adds 50 MB and a CLI surface. Pixel-count diff is all we need.
+  - PIL's ImageChops.difference returns a per-pixel-channel delta image;
+    getbbox() returns the smallest rect that bounds any non-zero pixel.
+    A non-None bbox means *something* changed; the bbox area is a useful
+    quick metric.
+
+Output sketch:
+
+  | Page              | Diff |
+  | ----------------- | ---- |
+  | dashboard         | 0    |
+  | jog               | 1240 |
+  | restart_confirm   | NEW  |
+  | tool_change       | DEL  |
+  | _summary_         | 1 changed, 1 new, 1 deleted of 20 |
+
+Exits 0 if no diffs; 1 otherwise. Intentionally tolerant — missing PIL
+or unreadable images degrade to "no diff data", not a workflow failure.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    from PIL import Image, ImageChops
+except ImportError:
+    print("error: Pillow not installed (`pip install pillow`)", file=sys.stderr)
+    sys.exit(2)
+
+
+def diff_image(fresh: Path, baseline: Path) -> dict:
+    """Return {pixels: int, bbox: tuple|None, status: str}."""
+    try:
+        with Image.open(fresh) as a_img, Image.open(baseline) as b_img:
+            a = a_img.convert("RGB")
+            b = b_img.convert("RGB")
+            if a.size != b.size:
+                return {"pixels": -1, "bbox": None, "status": "resized"}
+            diff = ImageChops.difference(a, b)
+            bbox = diff.getbbox()
+            if bbox is None:
+                return {"pixels": 0, "bbox": None, "status": "identical"}
+            # Count non-zero pixels via getextrema across channels.
+            # Cheap approx: bbox area is an upper bound on changed pixels.
+            bw, bh = bbox[2] - bbox[0], bbox[3] - bbox[1]
+            # Per-pixel count: sum of any-channel-nonzero.
+            mask = diff.convert("L").point(lambda p: 255 if p else 0)
+            changed = sum(1 for p in mask.getdata() if p)
+            return {"pixels": changed, "bbox": list(bbox), "bbox_area": bw * bh,
+                    "status": "changed"}
+    except OSError as e:
+        return {"pixels": -1, "bbox": None, "status": f"error: {e}"}
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    p.add_argument("fresh", type=Path, help="directory with this PR's PNGs")
+    p.add_argument("baseline", type=Path, help="directory with main's PNGs")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    args = p.parse_args(argv)
+
+    if not args.fresh.is_dir():
+        print(f"error: fresh dir not found: {args.fresh}", file=sys.stderr)
+        return 2
+    if not args.baseline.is_dir():
+        # Missing baseline isn't fatal — first run on a new repo state
+        # legitimately has no main yet. Emit a summary with everything
+        # marked NEW and exit cleanly so the workflow comment can still
+        # post.
+        args.baseline = None
+
+    fresh_names = {p.name for p in args.fresh.glob("*.png")}
+    baseline_names = (
+        {p.name for p in args.baseline.glob("*.png")} if args.baseline else set()
+    )
+
+    rows = []
+    changed = new_pages = deleted_pages = 0
+    for name in sorted(fresh_names | baseline_names):
+        if name not in baseline_names:
+            rows.append({"page": name, "status": "NEW", "pixels": None})
+            new_pages += 1
+        elif name not in fresh_names:
+            rows.append({"page": name, "status": "DEL", "pixels": None})
+            deleted_pages += 1
+        else:
+            d = diff_image(args.fresh / name, args.baseline / name)
+            rows.append({"page": name, "status": d["status"], "pixels": d["pixels"],
+                         "bbox": d.get("bbox")})
+            if d["status"] == "changed":
+                changed += 1
+
+    total = len(fresh_names | baseline_names)
+    summary = {
+        "total_pages": total,
+        "changed": changed,
+        "new": new_pages,
+        "deleted": deleted_pages,
+        "identical": total - changed - new_pages - deleted_pages,
+    }
+    report = {"summary": summary, "rows": rows}
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return 1 if changed + new_pages + deleted_pages else 0
+
+    print(f"### Per-page screenshot diff vs main")
+    print(f"_{summary['total_pages']} pages — "
+          f"{summary['identical']} identical, "
+          f"{summary['changed']} changed, "
+          f"{summary['new']} new, "
+          f"{summary['deleted']} deleted_")
+    print()
+    if changed + new_pages + deleted_pages == 0:
+        print("All pages render identically to `main`.")
+        return 0
+    print("| Page | Status | Δ pixels | Region |")
+    print("| ---- | ------ | -------- | ------ |")
+    for r in rows:
+        if r["status"] == "identical":
+            continue
+        if r["status"] == "changed":
+            bbox = r.get("bbox")
+            region = f"({bbox[0]},{bbox[1]})–({bbox[2]},{bbox[3]})" if bbox else ""
+            print(f"| `{r['page']}` | changed | {r['pixels']} | {region} |")
+        else:
+            print(f"| `{r['page']}` | {r['status']} | — | — |")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Phase E item. Extends the artifact-link comment landed in #25 (E20) with a Markdown table of per-page pixel diffs vs the baseline on main.

## `scripts/screenshot_diff.py`

Compares each fresh PNG against its main-side baseline using `PIL.ImageChops.difference` + `getbbox()`. Emits Markdown with one row per changed/new/deleted page:

```
| Page          | Status  | Δ pixels | Region            |
| ------------- | ------- | -------- | ----------------- |
| dashboard.png | changed | 138      | (59,80)–(156,136) |
| new_page.png  | NEW     | —        | —                 |
```

PIL gives both a bounded change region and a pixel-accurate diff count without an ImageMagick install. `python3-pil` is already on Ubuntu 24.04 — one extra apt package, no compile.

Tolerant: missing PIL, missing baseline dir, or per-image read errors fall back to "no diff data" instead of failing the workflow.

## Workflow integration

- Install `python3-pil` alongside the existing tools.
- New step "Diff screenshots vs main baseline" on `pull_request` events: pulls main's committed `screenshots/` via `git show` into a tmp dir (doesn't touch the working tree), runs the diff script, writes Markdown to `/tmp/screenshot_diff.md`.
- PR-comment body picks up the diff Markdown and embeds it after the existing artifact / run / blank-render lines.

Push to main and `workflow_dispatch` skip the diff step — the new commit IS the next baseline.

This PR will be the first to exercise the diff in CI; expect a small diff against main from runtime-drift labels (network uptime, EC cycle counters) — single-region changes ≪1000 pixels.

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_