### PR TITLE
UI C10: theme color tokens — `$name` lookup in TSV color fields

### DIFF
--- a/devices/embedded_ui.tsv
+++ b/devices/embedded_ui.tsv
@@ -59,6 +59,17 @@
 #   button's brighter background only when the page id matches.
 #
 # ============================================================
+# THEME (C10)
+#   Named color tokens, looked up via $name in any color/bg/border
+#   field. Identical hex values to the PALETTE block above — the
+#   tokens just give a single place to change the design system.
+#   Existing widgets keep their hand-coded #hex values; new widgets
+#   can use either form. To re-skin the UI (e.g. high-contrast),
+#   replace this one line.
+# ============================================================
+theme	page=#0A0F1A	panel=#111827	inset=#0F172A	border=#334155	border_subtle=#1F2937	section=#94A3B8	ink=#F8FAFC	muted=#94A3B8	accent=#7DD3FC	ok=#22C55E	warn=#F59E0B	fault=#EF4444	info=#0EA5E9	primary=#15803D	secondary=#B45309	neutral=#334155	destructive=#B91C1C	dro_bg=#0B1220	dro_lin=#1E40AF	dro_rot=#92400E	amber=#FBBF24	mint=#86EFAC	wcs=#7C3AED
+
+# ============================================================
 # bottom_nav -- shared 7-button bar (included by every page).
 # 7 tiles at 140 px with 10 px gaps fill 1040 px of the 1080-wide canvas.
 # Order mirrors the operator workflow:

--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -41,12 +41,53 @@ namespace kinematic = render::kinematic;
 namespace machine = render::machine;
 
 constexpr uint32_t kTransparent = 0x00000000U;
+
+// C10: theme tokens — named color slots declared once at the top of
+// embedded_ui.tsv via a `theme key1=#hex1 key2=#hex2 ...` record.
+// Widget color fields then reference `$key` instead of hand-coding the
+// hex. Operator-facing themes (high-contrast, outdoor, dark) become a
+// single TSV swap instead of touching every widget.
+struct ThemeToken {
+    char name[32];
+    uint32_t color;
+};
+constexpr uint32_t MAX_THEME_TOKENS = 64;
+static ThemeToken g_theme_tokens[MAX_THEME_TOKENS];
+static uint32_t g_theme_token_count = 0;
+
+uint32_t lookup_theme_token(const char* name) {
+    if (!name || !*name) return kTransparent;
+    for (uint32_t i = 0; i < g_theme_token_count; ++i) {
+        if (strcmp(g_theme_tokens[i].name, name) == 0) {
+            return g_theme_tokens[i].color;
+        }
+    }
+    return kTransparent;
+}
+
+bool set_theme_token(const char* name, uint32_t color) {
+    if (!name || !*name) return false;
+    for (uint32_t i = 0; i < g_theme_token_count; ++i) {
+        if (strcmp(g_theme_tokens[i].name, name) == 0) {
+            g_theme_tokens[i].color = color;
+            return true;
+        }
+    }
+    if (g_theme_token_count >= MAX_THEME_TOKENS) return false;
+    auto& slot = g_theme_tokens[g_theme_token_count++];
+    size_t i = 0;
+    while (i + 1 < sizeof(slot.name) && name[i]) { slot.name[i] = name[i]; ++i; }
+    slot.name[i] = '\0';
+    slot.color = color;
+    return true;
+}
 constexpr uint32_t MAX_LAYOUT_CHILDREN = 32;
 
 enum class RecordType : uint8_t {
     Unknown = 0,
     Page,
     Dialog,    // A4: Z-layer above pages; same parse shape as Page.
+    Theme,     // C10: declare named color tokens for $name lookups.
     Include,
     Child,
     Action,
@@ -230,6 +271,10 @@ uint8_t simple_hex(char c) {
 
 uint32_t parse_color(const char* s) {
     if (!s || *s == '\0') return kTransparent;
+    // C10: $name → theme token lookup.
+    if (s[0] == '$' && s[1]) {
+        return lookup_theme_token(s + 1);
+    }
     if (s[0] == '#' && s[1] && s[2] && s[3] && s[4] && s[5] && s[6]) {
         const uint8_t r = static_cast<uint8_t>(simple_hex(s[1]) * 16 + simple_hex(s[2]));
         const uint8_t g = static_cast<uint8_t>(simple_hex(s[3]) * 16 + simple_hex(s[4]));
@@ -303,6 +348,7 @@ RecordType parse_record_type(const char* s) {
     if (!s) return RecordType::Unknown;
     if (strcmp(s, "page") == 0) return RecordType::Page;
     if (strcmp(s, "dialog") == 0) return RecordType::Dialog;
+    if (strcmp(s, "theme") == 0) return RecordType::Theme;
     if (strcmp(s, "include") == 0) return RecordType::Include;
     if (strcmp(s, "child") == 0) return RecordType::Child;
     if (strcmp(s, "action") == 0) return RecordType::Action;
@@ -4575,6 +4621,7 @@ void reset_state() {
     g_focusable_count = 0;
     g_focus_index = -1;
     g_input_count = 0;
+    g_theme_token_count = 0;
     BuilderImage::clear_registry();
     clear_error();
     memset(g_widgets, 0, sizeof(g_widgets));
@@ -4759,6 +4806,22 @@ bool load_tsv(const char* buf, size_t len) {
         if (record_type == RecordType::Unknown) {
             set_error(line_no, "unknown record type");
             return false;
+        }
+        if (record_type == RecordType::Theme) {
+            // C10: theme record. Every k=v pair on the line registers a
+            // named color token. Subsequent widget records can reference
+            // it as `bg=$key` / `color=$key` / `border=$key`.
+            KeyValueField fields[16]{};
+            const uint32_t field_count = parse_fields(line, line_len, fields, 16);
+            for (uint32_t i = 0; i < field_count; ++i) {
+                if (!fields[i].key[0]) continue;
+                const uint32_t color = parse_color(fields[i].value);
+                if (!set_theme_token(fields[i].key, color)) {
+                    set_error(line_no, "theme token limit exceeded");
+                    return false;
+                }
+            }
+            continue;
         }
         if (record_type == RecordType::Page || record_type == RecordType::Dialog) {
             if (g_page_count >= MAX_PAGES) {

--- a/ui/ui_builder_tsv.hpp
+++ b/ui/ui_builder_tsv.hpp
@@ -38,6 +38,8 @@
 //   action=demo:cycle|demo:hold|demo:reset|demo:home|demo:jog+|demo:jog-
 //
 // Colors: #RRGGBB or name (red, green, blue, black, white, etc)
+//         or $token where token is defined by a top-level
+//         `theme name=#hex name=#hex ...` record (C10).
 // Font sizes: small=12, medium=16, large=24, xlarge=32
 //
 // Example:


### PR DESCRIPTION
Phase C item. Color fields (`bg`/`color`/`border`) in TSV widget records were hand-coded `#RRGGBB` hex. Re-skinning the UI (high-contrast, outdoor, dark) meant editing every widget across 1758 TSV lines in lockstep. Adds a `theme` record type that declares named color tokens once, referenced by widgets as `$name`.

## New surface

```
theme  page=#0A0F1A  panel=#111827  inset=#0F172A  border=#334155  ...

panel  id=foo  x=...  bg=$panel  border=$border  ...
label  id=foo  text=ALARM  color=$fault  bg=$inset  ...
```

## Implementation

- `RecordType::Theme` added. Parser routes Theme lines into `set_theme_token(key, color)`.
- `g_theme_tokens[MAX_THEME_TOKENS=64]` backs the lookup; `reset_state` zeroes the count on TSV reload so a future theme switch is just `load_tsv` with a different prelude.
- `parse_color` sees `$name` as first char and routes to `lookup_theme_token(name)`. Unknown tokens fall back to `kTransparent` (matches the existing "missing color" semantics so a typo doesn't crash render).
- The 23 design-system colours from the TSV header comment are now declared as tokens in a single `theme` line above `bottom_nav`. Existing widgets keep their hand-coded `#hex` values — no behaviour change.

## Verification

- `make TARGET=arm64` clean
- Boot smoke: CLI ready, echo, `[ec0] cycle=250us`, no PANIC
- 20/20 UI screenshots capture cleanly
- E19 diff vs main shows only runtime-drift on `ethercat` and `lights_out` — the theme line is parsed but no widget yet references it, so the visual is identical to main by design.

## Migration path

Add a new `theme ...` line on top of the TSV, then opportunistically flip widgets to `$token` references. A future PR can convert the full TSV in one pass to land a real re-skin. This commit lays the groundwork.

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_