### PR TITLE
UI D17: page-spanning status strip on bottom_nav

### DIFF
--- a/devices/embedded_ui.tsv
+++ b/devices/embedded_ui.tsv
@@ -82,6 +82,22 @@ theme	page=#0A0F1A	panel=#111827	inset=#0F172A	border=#334155	border_subtle=#1F2
 # ============================================================
 page	id=bottom_nav	title=NavBar
 panel	id=nav_root	x=0	y=1740	w=1080	h=180	bg=#0F172A	border=#1F2937
+# D17: page-spanning status strip at the top of every nav bar. Sits in the
+# 20 px band between the nav panel border and the row of nav buttons.
+# Operators get alarms/mode/WCS/program visible from any page without
+# having to switch back to the dashboard. Labels are scale=1 (8x16) —
+# the strip is intentionally narrow so the seven nav buttons keep their
+# 140 px hit boxes.
+label	id=nav_st_alarms_lbl	parent=nav_root	x=20	y=1740	w=80	h=18	text=ALARMS	color=#94A3B8	bg=#0F172A	scale=1
+label	id=nav_st_alarms_v	parent=nav_root	x=104	y=1740	w=60	h=18	text=0	color=#86EFAC	bg=#0F172A	bind=alarm:active_count	align=center	scale=1
+label	id=nav_st_mode_lbl	parent=nav_root	x=180	y=1740	w=60	h=18	text=MODE	color=#94A3B8	bg=#0F172A	scale=1
+label	id=nav_st_mode_v	parent=nav_root	x=244	y=1740	w=160	h=18	text=READY	color=#BAE6FD	bg=#0F172A	bind=mode	scale=1
+label	id=nav_st_wcs_lbl	parent=nav_root	x=420	y=1740	w=40	h=18	text=WCS	color=#94A3B8	bg=#0F172A	scale=1
+label	id=nav_st_wcs_v	parent=nav_root	x=464	y=1740	w=80	h=18	text=G54	color=#DDD6FE	bg=#0F172A	bind=wcs	scale=1
+label	id=nav_st_prog_lbl	parent=nav_root	x=560	y=1740	w=80	h=18	text=PROGRAM	color=#94A3B8	bg=#0F172A	scale=1
+label	id=nav_st_prog_v	parent=nav_root	x=644	y=1740	w=240	h=18	text=---	color=#F8FAFC	bg=#0F172A	bind=program_name	scale=1
+label	id=nav_st_page_lbl	parent=nav_root	x=900	y=1740	w=60	h=18	text=PAGE	color=#94A3B8	bg=#0F172A	scale=1
+label	id=nav_st_page_v	parent=nav_root	x=964	y=1740	w=116	h=18	text=---	color=#FBBF24	bg=#0F172A	bind=page_name	scale=1
 button	id=nav_dashboard	parent=nav_root	x=20	y=1760	w=140	h=140	text=HOME	bg=#1E293B	color=#F8FAFC	border=#475569	scale=2	focus=900
 button	id=nav_jog	parent=nav_root	x=170	y=1760	w=140	h=140	text=JOG	bg=#1E293B	color=#F8FAFC	border=#475569	scale=2	focus=910
 button	id=nav_mdi	parent=nav_root	x=320	y=1760	w=140	h=140	text=MDI	bg=#1E293B	color=#F8FAFC	border=#475569	scale=2	focus=920

--- a/ui/ui_builder_tsv.hpp
+++ b/ui/ui_builder_tsv.hpp
@@ -67,11 +67,14 @@ namespace ui_builder {
 
 // embedded_ui.tsv has ~953 widgets / ~169 actions raw, and 20 pages each
 // `include page=bottom_nav` — include_page_into_current clones bottom_nav's
-// 8 widgets and 7 actions into every including page, adding ~160 widgets
-// and ~140 actions. Working set is ~1113 widgets / ~309 actions; the prior
-// 256 / 128 caps aborted load_tsv mid-`machine_view` so no Widget* was
-// ever created and CI screenshots all rendered to a blank framebuffer.
-constexpr uint32_t MAX_WIDGETS = 1280;
+// widgets and actions into every including page. As bottom_nav grew to
+// host the D17 status strip (10 labels: alarms/mode/wcs/program/page),
+// the working set climbed from ~1113 to ~1313 widgets and overran the
+// previous MAX_WIDGETS=1280 cap — load_tsv aborted halfway through and
+// every page rendered the blank-fallback. Bump to 1536 for headroom;
+// add ~140 KB to .bss against the 128 MB image. The next time
+// bottom_nav grows another row, raise here.
+constexpr uint32_t MAX_WIDGETS = 1536;
 constexpr uint32_t MAX_PAGES = 32;
 constexpr uint32_t MAX_ACTIONS = 384;
 constexpr uint32_t MAX_CHILD_LINKS = 256;


### PR DESCRIPTION
Phase D item. Operators previously had to switch back to the dashboard to see alarm count / mode / WCS / loaded program — there was no peripheral signal from the other pages. Adds a 20 px status strip at the top of `bottom_nav` (y=1740..1758), visible on every page that includes the nav.

## Strip layout (scale=1, 8×16 glyph)

```
ALARMS N    MODE READY    WCS G54    PROGRAM <name>    PAGE <id>
```

| Field | Bind | Notes |
|---|---|---|
| `ALARMS N` | `alarm:active_count` | mint green text |
| `MODE READY` | `mode` | READY/RUNNING/ALARM/SETUP/... |
| `WCS G54` | `wcs` | G54..G59 |
| `PROGRAM` | `program_name` | falls back to `---` |
| `PAGE` | `page_name` | confirms the visible page id |

## `MAX_WIDGETS` bumped 1280 → 1536

Each `include page=bottom_nav` clones the nav's widgets into the including page, so 10 new strip labels × 20 pages = +200 widgets. The working set went from ~1113 to ~1313 and the prior 1280 cap aborted `load_tsv` at line 1776 (`widget limit exceeded`) — every page rendered blank. New cap costs ~140 KB extra `.bss` against the 128 MB QEMU image.

## Verification

- `make TARGET=arm64` clean
- Boot smoke: CLI ready, echo, `[ec0] cycle=250us`, no PANIC
- 20/20 UI screenshots capture cleanly
- E19 diff vs main reports **~230 changed pixels per page**, all in the (0,1740)..(1080,1758) band — exactly the new strip area, no collateral damage on the page content above.

## Future optimization

A proper "single status strip rendered once on top of all pages" that doesn't multiply through `include_page_into_current` would need an always-shown overlay Z-layer (sibling to A4's modal mechanism). Bigger architecture change; the clone-into-every-page approach gives identical operator UX today.

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_