### PR TITLE
UI D18: hold-to-confirm on destructive buttons

### DIFF
--- a/devices/embedded_ui.tsv
+++ b/devices/embedded_ui.tsv
@@ -193,7 +193,7 @@ button	id=cyc_start	parent=dash_root	x=780	y=170	w=260	h=160	text=START	bg=#1580
 button	id=cyc_hold	parent=dash_root	x=780	y=350	w=260	h=130	text=HOLD	bg=#B45309	color=#FFFFFF	scale=2	focus=30
 button	id=cyc_reset	parent=dash_root	x=780	y=500	w=260	h=110	text=RESET	bg=#334155	color=#F8FAFC	scale=2	focus=40
 button	id=cyc_home	parent=dash_root	x=780	y=630	w=260	h=110	text=HOME	bg=#0F766E	color=#FFFFFF	scale=2	focus=50
-button	id=cyc_estop	parent=dash_root	x=780	y=760	w=260	h=250	text=E-STOP	bg=#B91C1C	color=#FFFFFF	border=#FCA5A5	scale=3	focus=60
+button	id=cyc_estop	parent=dash_root	x=780	y=760	w=260	h=250	text=E-STOP	bg=#B91C1C	color=#FFFFFF	border=#FCA5A5	scale=3	hold=1500	focus=60
 
 # --- program info (panel y=1050, h=210) ---
 panel	id=dash_prog	parent=dash_root	x=20	y=1050	w=1040	h=210	bg=#111827	border=#334155
@@ -1701,7 +1701,7 @@ label	id=rc_caution_v	parent=rc_root	x=40	y=750	w=1000	h=80	text=Verify the spin
 
 panel	id=rc_ctl_panel	parent=rc_root	x=20	y=880	w=1040	h=400	bg=#111827	border=#334155
 label	id=rc_ctl_title	parent=rc_root	x=40	y=894	w=400	h=28	text=DECISION	color=#94A3B8	bg=#111827	scale=2
-button	id=rc_confirm	parent=rc_root	x=40	y=940	w=480	h=300	text=CONFIRM RESTART	bg=#15803D	color=#FFFFFF	scale=3	focus=940
+button	id=rc_confirm	parent=rc_root	x=40	y=940	w=480	h=300	text=CONFIRM RESTART	bg=#15803D	color=#FFFFFF	scale=3	hold=1500	focus=940
 button	id=rc_cancel	parent=rc_root	x=540	y=940	w=480	h=300	text=CANCEL	bg=#B91C1C	color=#FFFFFF	scale=3	focus=942
 
 action	widget=rc_confirm	event=click	target=restart:confirm

--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -3401,6 +3401,13 @@ public:
             bg = bright_bg_;
             highlight_border = true;
         }
+        // D18: amber overlay while a hold-to-confirm button is held.
+        // Tells the operator "keep holding" — release before
+        // spec_.hold_ms cancels the action.
+        if (hold_start_ns_ != 0) {
+            bg = Color(245, 158, 11);  // tailwind amber-500
+            highlight_border = true;
+        }
         set_colors(bg, bg, Color(bg.r / 2, bg.g / 2, bg.b / 2), fg_);
 
         // Buttons may bind their label to a string snapshot field (e.g. the
@@ -3457,6 +3464,22 @@ public:
     bool on_event(const UIEvent& event) override {
         if (event.type == kernel::ui::EventType::TouchDown && contains(event.touch.x, event.touch.y)) {
             set_focus_widget(this);
+            // D18: start the hold timer (any button — only matters if
+            // spec_.hold_ms > 0). Use the platform timer if available;
+            // boot-time touches before the timer is up are treated as
+            // instant taps (hold_ms 0).
+            if (auto* timer = kernel::g_platform ? kernel::g_platform->get_timer_ops() : nullptr) {
+                hold_start_ns_ = timer->get_system_time_ns();
+            } else {
+                hold_start_ns_ = 0;
+            }
+            mark_dirty();
+        }
+        if (event.type == kernel::ui::EventType::TouchMove && hold_start_ns_ != 0 &&
+            !contains(event.touch.x, event.touch.y)) {
+            // Slid off the button mid-hold — cancel.
+            hold_start_ns_ = 0;
+            mark_dirty();
         }
         const bool handled = kernel::ui::Button::on_event(event);
         if (handled && event.type == kernel::ui::EventType::TouchUp && contains(event.touch.x, event.touch.y)) {
@@ -3464,11 +3487,35 @@ public:
                                  spec_.id, nullptr,
                                  static_cast<long>(event.touch.x),
                                  static_cast<long>(event.touch.y));
-            if (const char* target = action_target_for_widget(spec_.id, BuilderEvent::Click, spec_.action)) {
-                run_action_target(target);
+            // D18: suppress the action if the operator released before
+            // the configured hold_ms elapsed. zero hold_ms keeps the
+            // single-tap behaviour unchanged.
+            bool fire = true;
+            if (spec_.hold_ms > 0 && hold_start_ns_ != 0) {
+                if (auto* timer = kernel::g_platform ? kernel::g_platform->get_timer_ops() : nullptr) {
+                    const uint64_t now = timer->get_system_time_ns();
+                    const uint64_t elapsed_ns = now - hold_start_ns_;
+                    const uint64_t need_ns = static_cast<uint64_t>(spec_.hold_ms) * 1'000'000ULL;
+                    if (elapsed_ns < need_ns) fire = false;
+                } else {
+                    fire = false;  // can't time — fail safe (no fire)
+                }
             }
+            hold_start_ns_ = 0;
+            mark_dirty();
+            if (fire) {
+                if (const char* target = action_target_for_widget(spec_.id, BuilderEvent::Click, spec_.action)) {
+                    run_action_target(target);
+                }
+            }
+        } else if (event.type == kernel::ui::EventType::TouchUp) {
+            // Release outside the button cancels the hold visualisation.
+            if (hold_start_ns_ != 0) { hold_start_ns_ = 0; mark_dirty(); }
         } else if (event.type == kernel::ui::EventType::KeyDown && is_focused(this) &&
                    (event.key.keycode == '\r' || event.key.keycode == ' ')) {
+            // Keyboard "click" — bypass the hold-to-confirm gate. Operators
+            // using physical keys/joypad shouldn't need to hold; the
+            // touch-screen friction was the concern. Documented behaviour.
             if (const char* target = action_target_for_widget(spec_.id, BuilderEvent::Click, spec_.action)) {
                 run_action_target(target);
             }
@@ -3490,6 +3537,10 @@ private:
     char    last_label_[MAX_FIELD_LEN]{};
     int8_t  last_active_match_ = -1;
     int8_t  last_goto_self_ = -1;
+    // D18: hold-to-confirm timer. 0 means "not currently held". Set on
+    // TouchDown inside the button, cleared on TouchUp / TouchMove-off /
+    // boot. Compared against spec_.hold_ms at release.
+    uint64_t hold_start_ns_ = 0;
 };
 
 class BuilderPanel final : public Panel {
@@ -4814,6 +4865,12 @@ WidgetSpec parse_widget(const char* record, size_t len) {
         }
         else if (strcmp(key_buf, "active_if") == 0) {
             copy_field(spec.active_if, sizeof(spec.active_if), val_buf, strlen(val_buf));
+        }
+        else if (strcmp(key_buf, "hold") == 0) {
+            // D18: hold-to-confirm. Non-zero hold_ms makes the button
+            // require a sustained touch >= N ms before lifting.
+            const int32_t n = simple_atoi(val_buf);
+            spec.hold_ms = n > 0 ? n : 0;
         }
         // B8: layout overrides on Container/Panel widgets.
         else if (strcmp(key_buf, "cols") == 0) {

--- a/ui/ui_builder_tsv.hpp
+++ b/ui/ui_builder_tsv.hpp
@@ -161,6 +161,14 @@ struct WidgetSpec {
     int32_t layout_rows = 0;
     int32_t layout_gap  = 0;
     int32_t layout_pad  = -1;  // negative sentinel: keep the default 16
+
+    // D18: hold-to-confirm. 0 = single-tap fires the action (default,
+    // unchanged). Non-zero = the operator must keep the touch on the
+    // button for >= hold_ms milliseconds before lifting; a release
+    // before then suppresses the action. Used for destructive verbs
+    // (E-STOP / ABORT / restart). The button paints an amber overlay
+    // while held to signal "keep holding".
+    int32_t hold_ms = 0;
 };
 
 // Parse TSV record into WidgetSpec


### PR DESCRIPTION
Phase D item. Single-tap on destructive verbs (E-STOP, CONFIRM RESTART) had no safety against accidental contact. The agent in PR #20 flagged it as a UX gap; D18 adds a per-button `hold=N` (ms) attribute that requires sustained touch before the action fires. Tap-and-release-quickly suppresses the action.

## TSV opt-in

```
button  id=cyc_estop   ... hold=1500 ...
button  id=rc_confirm  ... hold=1500 ...
```

## Behaviour

- **TouchDown inside button** records system time, overlays amber bg (tailwind amber-500) to signal "keep holding".
- **TouchMove off the button** cancels the hold (no action, bg restores).
- **TouchUp inside button**:
  - `elapsed >= hold_ms` → click action fires as usual.
  - `elapsed < hold_ms` → action dropped silently, amber overlay disappears.
- **`hold_ms == 0`** (default for every existing button) keeps the legacy single-tap behaviour bit-for-bit.

## Keyboard bypass

Enter / Space when focused intentionally bypasses the hold gate. The accidental-touch concern is touch-screen-specific; operators using a keyboard or joypad don't need to hold. Documented inline.

## TSV opt-ins this PR

- `cyc_estop` on dashboard: `hold=1500`
- `rc_confirm` in `restart_confirm` dialog: `hold=1500`

The dialog's CANCEL button keeps single-tap (bail-out, not destructive).

## Verification

- `make TARGET=arm64` clean
- Boot smoke: CLI ready, echo, `[ec0] cycle=250us`, no PANIC
- 20/20 UI screenshots capture cleanly. Static screenshot can't animate the hold; the unmodified-render path is intact (no diff vs main on either button — render only differs while held).

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_