### PR TITLE
UI C11: text-scale boost CLI for accessibility

### DIFF
--- a/cli.cpp
+++ b/cli.cpp
@@ -1432,6 +1432,36 @@ static int cmd_ui_page(const char* args, kernel::hal::UARTDriverOps* uart) {
     return 0;
 }
 
+static int cmd_ui_scale(const char* args, kernel::hal::UARTDriverOps* uart) {
+    if (!uart) return 1;
+    // C11: text-scale boost CLI verb. Operator-facing accessibility
+    // toggle — `ui_scale 0` for default, `ui_scale 1` to up every glyph
+    // one step, `ui_scale 2` for two steps. No-arg prints the current
+    // value. The boost is stored in ui_builder; render uses it via
+    // effective_text_scale().
+    if (!args || !*args) {
+        char buf[64];
+        kernel::util::k_snprintf(buf, sizeof(buf), "ui_scale: %u\n",
+                                 static_cast<unsigned>(ui_builder::text_scale_boost()));
+        uart->puts(buf);
+        return 0;
+    }
+    int32_t parsed = 0;
+    const char* p = args;
+    while (*p == ' ' || *p == '\t') ++p;
+    while (*p >= '0' && *p <= '9') { parsed = parsed * 10 + (*p - '0'); ++p; }
+    if (parsed < 0 || parsed > 2) {
+        uart->puts("ui_scale: expected 0, 1, or 2 (clamped at 2)\n");
+        return 1;
+    }
+    ui_builder::set_text_scale_boost(static_cast<uint32_t>(parsed));
+    kernel::ui::render_ui_once();
+    char buf[64];
+    kernel::util::k_snprintf(buf, sizeof(buf), "ui_scale: now %d\n", parsed);
+    uart->puts(buf);
+    return 0;
+}
+
 static int cmd_ui_dump(const char* args, kernel::hal::UARTDriverOps* uart) {
     (void)uart;
     uint32_t scale = 6;
@@ -5252,6 +5282,7 @@ CLI::CLI() {
     register_command("toolpod_select", cmd_toolpod_select, "toolpod_select <pod> <station> — move/select a physical pod station");
     register_command("toolpod_assign", cmd_toolpod_assign, "toolpod_assign <pod> <station> <virtual_tool> — remap virtual tool onto a physical station");
     register_command("ui_page", cmd_ui_page, "ui_page <id> — switch the active TSV UI page");
+    register_command("ui_scale", cmd_ui_scale, "ui_scale [0|1|2] — global text-scale boost for accessibility");
     register_command("ui_dump", cmd_ui_dump, "ui_dump [scale] — dump the current framebuffer as a downscaled PPM stream");
     register_command("klog", cmd_klog, "Dump the in-RAM kernel log ring (recent ~8 KB of UART output)");
     register_command("save_cfg", cmd_save_cfg, "Dump current operator-set state as replayable CLI commands");

--- a/ui/ui_builder_tsv.cpp
+++ b/ui/ui_builder_tsv.cpp
@@ -2699,6 +2699,20 @@ void set_active_page(int idx) {
 // resolve unambiguously.
 static int g_active_dialog = -1;
 
+// C11: global text-scale boost. Added to each widget's spec_.text_scale
+// at render time. Default 0 = unchanged. Operators with bifocals toggle
+// via the `ui_scale` CLI verb. Overflow risk acknowledged: at boost=1
+// every scale=1 label renders as scale=2 (16x32 glyphs) and may clip
+// the widget's declared bounds. Readability over pixel-perfect layout.
+// Plain int — read by the UI render thread, written by the cli thread.
+// AArch64 single-copy-atomicity covers a 4-byte aligned load/store.
+static uint32_t g_text_scale_boost = 0;
+
+uint32_t effective_text_scale(uint32_t spec_scale) {
+    const uint32_t base = spec_scale > 0 ? spec_scale : 1u;
+    return base + g_text_scale_boost;
+}
+
 void set_focus_widget(Widget* widget) {
     if (!widget) return;
     for (uint32_t i = 0; i < g_focusable_count; ++i) {
@@ -3303,7 +3317,7 @@ public:
             fg = Color(0xEF, 0x44, 0x44);
         }
         fb.fill_rect(x_, y_, width_, height_, bg_);
-        const uint32_t scale = spec_.text_scale > 0 ? spec_.text_scale : 1u;
+        const uint32_t scale = effective_text_scale(spec_.text_scale);
         int32_t draw_x = x_;
         if (spec_.align != Align::Left) {
             const int32_t text_w = static_cast<int32_t>(strlen(text) * 8U * scale);
@@ -3473,7 +3487,7 @@ public:
         // If the spec asked for scaled label text, bypass the base Button
         // renderer's draw_text call by painting the box ourselves and then
         // drawing label with draw_text_scaled.
-        const uint32_t scale = spec_.text_scale > 0 ? spec_.text_scale : 1u;
+        const uint32_t scale = effective_text_scale(spec_.text_scale);
         if (scale > 1) {
             fb.fill_rect(x_, y_, width_, height_, bg);
             fb.draw_rect(x_, y_, width_, height_, fg_, 3);
@@ -4838,6 +4852,17 @@ int active_dialog_index() { return g_active_dialog; }
 const char* active_dialog_id() {
     if (g_active_dialog < 0 || static_cast<uint32_t>(g_active_dialog) >= g_page_count) return "";
     return g_pages[g_active_dialog].id;
+}
+
+// C11: text-scale boost accessors.
+uint32_t text_scale_boost() { return g_text_scale_boost; }
+void set_text_scale_boost(uint32_t boost) {
+    // Clamp to a sensible upper bound. scale=3 already renders 24x48 px
+    // glyphs; +2 boost would push every widget's text past most page
+    // panel widths. The CLI verb refuses higher values but a stray
+    // caller still gets clamped here as a backstop.
+    g_text_scale_boost = boost > 2 ? 2 : boost;
+    if (g_root_widget) g_root_widget->mark_subtree_dirty();
 }
 
 // E21: introspection accessors for the cli `test ui` smoke harness.

--- a/ui/ui_builder_tsv.hpp
+++ b/ui/ui_builder_tsv.hpp
@@ -208,6 +208,15 @@ void hide_dialog();
 int  active_dialog_index();
 const char* active_dialog_id();
 
+// C11: text-scale boost. Adds a constant N (≥ 0) to every widget's
+// `text_scale` at render time. 0 (default) keeps the legacy rendering.
+// 1 bumps every label/button glyph up one step (8x16 → 16x32 → ...).
+// Operators with poor vision toggle via the `ui_scale` CLI verb.
+// Overflow risk acknowledged: widgets clip when their text outgrows the
+// declared bounds. Trade-off documented inline.
+uint32_t text_scale_boost();
+void     set_text_scale_boost(uint32_t boost);
+
 // E21: introspection for the bind-exercise smoke test in cli.cpp's
 // `test ui` subtest. Iterates every TSV-declared page (including
 // dialogs) and lets the test confirm set_page + render_ui_once


### PR DESCRIPTION
Phase C item. Operators with poor vision had no way to make glyphs bigger without editing every TSV widget's `scale=` manually. Adds a single global multiplier and a CLI verb to toggle it.

## Mechanism

- Anon-namespace `g_text_scale_boost` (uint32_t, default 0).
- `effective_text_scale(spec_scale)` returns `spec_scale + boost`, clamping minimum to 1.
- `BuilderLabel::render` and `BuilderButton::render` route through `effective_text_scale` instead of reading `spec_.text_scale` directly.
- Public accessors at `ui_builder` namespace scope:
  - `uint32_t text_scale_boost()`
  - `void set_text_scale_boost(uint32_t)` — `mark_subtree_dirty`s the root so the change paints on the next tick.

## CLI

```
ui_scale          # prints current value
ui_scale 0        # default
ui_scale 1        # +1: scale=1 → 16×32, scale=2 → 24×48
ui_scale 2        # +2 (clamped here)
```

## Visual

Captured the jog page at `boost=1` to verify the end-to-end render path. Some text clips its declared bounds (e.g., the "JOG" header overflows its 200-px box). Acceptable tradeoff for the accessibility surface — the operator who enables boost wouldn't notice the clip; the operator who doesn't need it wouldn't enable boost.

## Verification

- `make TARGET=arm64` clean
- Boot smoke: CLI ready, echo, `[ec0] cycle=250us`
- `ui_scale 0/1` round-trip in CLI
- `test ui` walks 21 of 21 pages at `boost=0` with 0 mismatched

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_