### PR TITLE
UI B5 (MVP): `ui_reload` CLI verb for live TSV reload

### DIFF
--- a/cli.cpp
+++ b/cli.cpp
@@ -1432,6 +1432,53 @@ static int cmd_ui_page(const char* args, kernel::hal::UARTDriverOps* uart) {
     return 0;
 }
 
+static int cmd_ui_reload(const char* args, kernel::hal::UARTDriverOps* uart) {
+    if (!uart) return 1;
+    // B5 (minimum-viable form): re-read the UI TSV from VFS and feed it
+    // to ui_builder::load_tsv. Operators on the SD-card workflow drop a
+    // fresh embedded_ui.tsv at the canonical path and trigger reload
+    // from the CLI; the kernel rebuilds the widget tree without a
+    // restart. Cuts the edit-test cycle from rebuild-and-boot (~30 s)
+    // to "save + ui_reload" (~1 s).
+    //
+    // The full Phase B5 "live preview WebSocket" path will eventually
+    // wrap this with a network trigger from the editor, but the actual
+    // value is the reload itself — not the transport. CLI now,
+    // WebSocket later when the network surface needs it.
+    const char* path = (args && *args) ? args : "system/ui/embedded_ui.tsv";
+    while (*path == ' ' || *path == '\t') ++path;
+    const char* data = nullptr; size_t len = 0;
+    if (!kernel::vfs::lookup(path, data, len) || !data || len == 0) {
+        uart->puts("ui_reload: VFS lookup failed for ");
+        uart->puts(path);
+        uart->puts("\n");
+        return 1;
+    }
+    char info[160];
+    kernel::util::k_snprintf(info, sizeof(info),
+        "ui_reload: source %s len=%lu\n",
+        path, static_cast<unsigned long>(len));
+    uart->puts(info);
+    const bool ok = ui_builder::load_tsv(data, len);
+    if (!ok) {
+        kernel::util::k_snprintf(info, sizeof(info),
+            "ui_reload: parse FAILED at line %u: %s\n",
+            static_cast<unsigned>(ui_builder::last_error_line()),
+            ui_builder::last_error());
+        uart->puts(info);
+        return 1;
+    }
+    // Force a synchronous render so the operator sees the result
+    // immediately rather than 100 ms later.
+    kernel::ui::render_ui_once();
+    kernel::util::k_snprintf(info, sizeof(info),
+        "ui_reload: OK active=%s pages=%u\n",
+        ui_builder::active_page_id(),
+        static_cast<unsigned>(ui_builder::page_count()));
+    uart->puts(info);
+    return 0;
+}
+
 static int cmd_ui_scale(const char* args, kernel::hal::UARTDriverOps* uart) {
     if (!uart) return 1;
     // C11: text-scale boost CLI verb. Operator-facing accessibility
@@ -5283,6 +5330,7 @@ CLI::CLI() {
     register_command("toolpod_assign", cmd_toolpod_assign, "toolpod_assign <pod> <station> <virtual_tool> — remap virtual tool onto a physical station");
     register_command("ui_page", cmd_ui_page, "ui_page <id> — switch the active TSV UI page");
     register_command("ui_scale", cmd_ui_scale, "ui_scale [0|1|2] — global text-scale boost for accessibility");
+    register_command("ui_reload", cmd_ui_reload, "ui_reload [vfs-path] — re-read the TSV and rebuild the widget tree");
     register_command("ui_dump", cmd_ui_dump, "ui_dump [scale] — dump the current framebuffer as a downscaled PPM stream");
     register_command("klog", cmd_klog, "Dump the in-RAM kernel log ring (recent ~8 KB of UART output)");
     register_command("save_cfg", cmd_save_cfg, "Dump current operator-set state as replayable CLI commands");


### PR DESCRIPTION
Phase B item — closes Phase B with a minimum-viable form of B5. The full WebSocket-driven live preview from the editor is multi-PR (needs a TCP/HTTP listener that doesn't exist yet), but the value of B5 is the kernel-side reload itself, not the network transport. This lands the reload mechanism via CLI; a future PR can wrap it with WebSocket.

## CLI

```
miniOS> ui_reload
ui_reload: source system/ui/embedded_ui.tsv len=156598
ui_reload: OK active=bottom_nav pages=21

miniOS> ui_reload  some/other/path.tsv
...
```

## Mechanism

- `kernel::vfs::lookup` resolves the path (defaults to `system/ui/embedded_ui.tsv`). The VFS layer already merges the embedded blob and an optional SD-card override — drop a fresh TSV onto the SD card and `ui_reload` picks it up without a kernel rebuild.
- `ui_builder::load_tsv` runs `reset_state` internally — widget tree, focus chain, dialog state, and theme tokens all clear before re-parsing.
- `kernel::ui::render_ui_once` forces a synchronous repaint so the operator sees the result immediately.
- Parse errors surface line number + `last_error` so the operator can correct the TSV without scrolling boot log.

## Operator workflow

1. Edit `devices/embedded_ui.tsv` in `tools/ui_editor/`.
2. SCP / sneakernet the file onto the SD card at `/system/ui/embedded_ui.tsv`.
3. `miniOS> ui_reload`
4. New UI active. Iterate.

Edit-test cycle drops from rebuild-and-boot (~30 s) to **save + `ui_reload`** (~1 s).

## Future WebSocket form (out of scope)

Editor connects to a kernel-side WS endpoint, POSTs the TSV body, kernel calls `ui_reload` with the received buffer. Same backend, different transport. Recommended as the next Phase B PR once an HTTP server lands.

## Verification

- `make TARGET=arm64` clean
- Boot smoke: CLI ready, echo, `[ec0] cycle=250us`
- `ui_reload` round-trips on the embedded TSV — 21 pages reloaded, `active=bottom_nav` (first non-dialog page in TSV order, matches the existing post-reload landing behaviour).

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_