### PR TITLE
hal: fix virtio-net header size for VIRTIO_F_VERSION_1

### DIFF
--- a/hal/shared/virtio_net.hpp
+++ b/hal/shared/virtio_net.hpp
@@ -89,8 +89,11 @@ struct VirtqUsed {
     uint16_t avail_event;
 } __attribute__((packed));
 
-// Virtio-net packet header without VIRTIO_NET_F_MRG_RXBUF. Because this driver
-// never negotiates mergeable RX buffers, the device-visible header is 10 bytes.
+// Modern virtio-net header (12 bytes). VIRTIO_F_VERSION_1 mandates the
+// num_buffers trailer even when VIRTIO_NET_F_MRG_RXBUF isn't negotiated —
+// the field is just always-zero on TX and ignored on RX in that case.
+// Using the legacy 10-byte layout against a v1 device shifts every TX
+// frame by 2 bytes (dst MAC truncates by 2; see virtio 1.1 §5.1.6).
 struct VirtioNetHdr {
     uint8_t  flags;
     uint8_t  gso_type;
@@ -98,6 +101,7 @@ struct VirtioNetHdr {
     uint16_t gso_size;
     uint16_t csum_start;
     uint16_t csum_offset;
+    uint16_t num_buffers;
 } __attribute__((packed));
 
 class VirtioNetDriver : public kernel::hal::net::NetworkDriverOps {


### PR DESCRIPTION
## Summary

The virtio-net driver negotiated `VIRTIO_F_VERSION_1` but used the legacy 10-byte `virtio_net_hdr`. Per virtio 1.1 §5.1.6, modern (v1) devices always carry the `num_buffers` trailer — the device-visible header is 12 bytes, even when `VIRTIO_NET_F_MRG_RXBUF` isn't negotiated.

The 2-byte mismatch corrupted every TX and RX frame: the device interpreted 2 bytes of our payload as `num_buffers`, shifting the Ethernet header. In a pcap dump:

```
0000  ff ff ff ff 52 54 00 12 34 56 08 00 45 00 ...
      ^^^^^^^^^^^                       ^^^^^
      dst MAC truncated to 4 bytes       IP header
```

That truncation was the root cause of the cascade of failures in the B5 end-to-end test:
- DHCP discover went out malformed → no offer
- ARP requests went out malformed → no replies
- hostfwd UDP couldn't be decoded on RX (also affected — 2 extra bytes prepended to every L2 frame)

After the fix, the full path works on the existing 3-NIC layout (eth0 HMI / eth1 ec_a / eth2 ec_b+fake_slave):

```
[hmi] dhcp lease ip=10.0.2.15
[hmi] arp learned ip=10.0.2.2 mac=52:55:0a:00:02:02
[hmi] tsv-upload session=... complete ... -> load_tsv
[hmi] tsv-upload load OK; active=push_demo pages=1
```

## Test plan
- [x] `make TARGET=arm64` builds clean
- [x] Boot QEMU with 3-NIC layout (n0 user-mode hostfwd, n1/n2 socket-pair) — net-roles route correctly
- [x] DHCP lease obtained on eth0 (user-mode SLIRP)
- [x] ARP resolution works (gateway MAC learned)
- [x] hostfwd UDP datagram delivered to kernel
- [x] TSV upload reassembles and `ui_builder::load_tsv` activates new page

https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_