### PR TITLE
net: per-NIC RX demux via Netif

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ ifeq ($(TARGET),arm64)
     HAL_CPP    = $(HAL_DIR)/hal_qemu_arm64.cpp hal/shared/virtio_net.cpp \
                  hal/shared/virtio_gpu.cpp hal/shared/virtio_blk.cpp \
                  hal/shared/e1000.cpp hal/shared/pci.cpp hal/shared/xhci.cpp hal/shared/sdcard.cpp \
-                 hal/shared/virtio_input.cpp
+                 hal/shared/virtio_input.cpp hal/shared/netif.cpp
     LINKER     = $(HAL_DIR)/linker.ld
     # Disable libgcc outline-atomics. Not needed now LSE is mandated by
     # -march, and its discovery ctor reads a nonexistent aux vector.
@@ -119,7 +119,7 @@ ifeq ($(TARGET),riscv64)
                  hal/shared/virtio_blk.cpp \
                  hal/shared/e1000.cpp hal/shared/pci.cpp hal/shared/xhci.cpp \
                  hal/shared/sdcard.cpp \
-                 hal/shared/virtio_input.cpp
+                 hal/shared/virtio_input.cpp hal/shared/netif.cpp
     LINKER     = $(HAL_DIR)/linker.ld
     # -fno-pic/-fno-pie stops the compiler from emitting GOT-indirect
     # address-of-symbol sequences. On a freestanding kernel nothing

--- a/hal/shared/netif.cpp
+++ b/hal/shared/netif.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#include "netif.hpp"
+
+namespace kernel::net {
+
+Netif g_netifs[MAX_NETIFS];
+
+void Netif::bind(int if_idx, kernel::hal::net::NetworkDriverOps* nic) noexcept {
+    if_idx_ = if_idx;
+    nic_ = nic;
+}
+
+bool Netif::register_listener(EthListener* l) noexcept {
+    if (!l || listener_count_ >= MAX_LISTENERS) return false;
+    for (size_t i = 0; i < listener_count_; ++i) {
+        if (listeners_[i] == l) return true;  // already registered
+    }
+    listeners_[listener_count_++] = l;
+    return true;
+}
+
+void Netif::unregister_listener(EthListener* l) noexcept {
+    for (size_t i = 0; i < listener_count_; ++i) {
+        if (listeners_[i] == l) {
+            for (size_t j = i + 1; j < listener_count_; ++j) {
+                listeners_[j - 1] = listeners_[j];
+            }
+            listeners_[--listener_count_] = nullptr;
+            return;
+        }
+    }
+}
+
+void Netif::rx_trampoline(int if_idx, const uint8_t* data, size_t len, void* ctx) noexcept {
+    auto* self = static_cast<Netif*>(ctx);
+    if (self) self->dispatch(if_idx, data, len);
+}
+
+void Netif::dispatch(int if_idx, const uint8_t* data, size_t len) noexcept {
+    if (!data || len < 14) return;
+    const uint16_t et_be = static_cast<uint16_t>((data[12] << 8) | data[13]);
+    for (size_t i = 0; i < listener_count_; ++i) {
+        auto* l = listeners_[i];
+        if (!l) continue;
+        const uint16_t want = l->ethertype();
+        if (want != ETHERTYPE_ANY && want != et_be) continue;
+        if (nic_) l->on_eth_frame(if_idx, *nic_, data, len);
+    }
+}
+
+size_t Netif::poll(size_t budget) noexcept {
+    if (!nic_) return 0;
+    return nic_->poll_rx(&rx_trampoline, this, budget);
+}
+
+Netif* netif_bind(int if_idx, kernel::hal::net::NetworkDriverOps* nic) noexcept {
+    if (if_idx < 0 || static_cast<size_t>(if_idx) >= MAX_NETIFS) return nullptr;
+    g_netifs[if_idx].bind(if_idx, nic);
+    return &g_netifs[if_idx];
+}
+
+Netif* netif_get(int if_idx) noexcept {
+    if (if_idx < 0 || static_cast<size_t>(if_idx) >= MAX_NETIFS) return nullptr;
+    Netif* n = &g_netifs[if_idx];
+    return (n->nic() != nullptr) ? n : nullptr;
+}
+
+} // namespace kernel::net

--- a/hal/shared/netif.hpp
+++ b/hal/shared/netif.hpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+#pragma once
+
+// Per-NIC RX demux. A Netif binds to one kernel::hal::net::NetworkDriverOps
+// and dispatches incoming Ethernet frames to registered listeners. The
+// service that "owns" the NIC (typically because its IRQ targets that
+// service's worker core) drives the poll loop; additional services can
+// register filtered listeners to co-exist on the same wire without
+// editing the owner's handler.
+//
+// Why per-NIC and not global: each NIC's poll/IRQ-affinity is bound to a
+// specific worker core via route_net_irq. RX work for nic[i] runs on the
+// core that owns nic[i]; running listener dispatch off-thread would lose
+// that affinity. The netif is just a dispatcher, not a thread.
+
+#include "../../hal.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace kernel::net {
+
+// Catch-all sentinel for EthListener::ethertype() — receives every frame
+// regardless of EtherType. Specific value (e.g. 0x88A4 for EtherCAT,
+// 0x0800 for IPv4) filters at dispatch time. The dispatcher walks
+// listeners in registration order; multiple matching listeners all see
+// the frame.
+constexpr uint16_t ETHERTYPE_ANY = 0u;
+
+class EthListener {
+public:
+    virtual ~EthListener() = default;
+    // Return ETHERTYPE_ANY to see every frame, else a specific EtherType
+    // (host byte order; the dispatcher byte-swaps the wire value).
+    virtual uint16_t ethertype() const noexcept = 0;
+    // Called for each matching frame. `data` points at the Ethernet
+    // header; `len` includes the header.
+    virtual void on_eth_frame(int if_idx,
+                              kernel::hal::net::NetworkDriverOps& nic,
+                              const uint8_t* data, size_t len) noexcept = 0;
+};
+
+class Netif {
+public:
+    static constexpr size_t MAX_LISTENERS = 4;
+    void bind(int if_idx, kernel::hal::net::NetworkDriverOps* nic) noexcept;
+    bool register_listener(EthListener* l) noexcept;
+    void unregister_listener(EthListener* l) noexcept;
+    // Drain up to `budget` frames from the NIC's RX queue, dispatching
+    // each to matching listeners. Returns frame count.
+    size_t poll(size_t budget) noexcept;
+    int if_idx() const noexcept { return if_idx_; }
+    kernel::hal::net::NetworkDriverOps* nic() const noexcept { return nic_; }
+private:
+    static void rx_trampoline(int if_idx, const uint8_t* data, size_t len, void* ctx) noexcept;
+    void dispatch(int if_idx, const uint8_t* data, size_t len) noexcept;
+    int if_idx_ = -1;
+    kernel::hal::net::NetworkDriverOps* nic_ = nullptr;
+    EthListener* listeners_[MAX_LISTENERS]{};
+    size_t listener_count_ = 0;
+};
+
+constexpr size_t MAX_NETIFS = 4;
+extern Netif g_netifs[MAX_NETIFS];
+
+// Bind a Netif to a NIC index. Returns the Netif on success, nullptr if
+// idx is out of range. Safe to call multiple times — re-binds the slot.
+Netif* netif_bind(int if_idx, kernel::hal::net::NetworkDriverOps* nic) noexcept;
+// Retrieve a previously-bound netif. Returns nullptr if not bound.
+Netif* netif_get(int if_idx) noexcept;
+
+} // namespace kernel::net

--- a/hmi/hmi_service.cpp
+++ b/hmi/hmi_service.cpp
@@ -423,12 +423,6 @@ void Service::set_static_config(uint32_t ip, uint32_t netmask, uint32_t gateway)
     if (!config_.dhcp_enable) apply_static_config();
 }
 
-void Service::rx_trampoline(int, const uint8_t* data, size_t len, void* ctx) noexcept {
-    auto* c = static_cast<Context*>(ctx);
-    if (!c || !c->self || !c->nic) return;
-    c->self->handle_eth_frame(*c->nic, data, len);
-}
-
 void Service::send_raw_response(kernel::hal::net::NetworkDriverOps& nic,
                                 const uint8_t* dst_mac,
                                 uint8_t opcode, uint8_t status,
@@ -1273,10 +1267,15 @@ void Service::thread_entry(void* arg) {
             log_ip_line("[hmi] selftest target=", self->config_.ping_selftest_target);
         }
     }
-    Context ctx{self, nic};
+    auto* netif = kernel::net::netif_bind(static_cast<int>(self->nic_idx_), nic);
+    if (!netif) {
+        if (uart) uart->puts("[hmi] netif bind FAILED — nic_idx out of range\n");
+        return;
+    }
+    netif->register_listener(self);
     for (;;) {
         self->maybe_start_dhcp(*nic);
-        (void)nic->poll_rx(&rx_trampoline, &ctx, 8);
+        (void)netif->poll(8);
         self->process_ping(*nic);
         if (self->config_.ping_selftest_enable &&
             !self->ping_selftest_started_ &&

--- a/hmi/hmi_service.hpp
+++ b/hmi/hmi_service.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "core.hpp"
+#include "hal/shared/netif.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -23,9 +24,20 @@ struct Config {
     uint32_t ping_selftest_timeout_ms = 3000;
 };
 
-class Service {
+class Service : public kernel::net::EthListener {
 public:
     static constexpr uint16_t ETHERTYPE = 0x88B5;
+    // EthListener: catch-all so we keep receiving every frame type the
+    // HMI service handles (raw 0x88B5, ARP 0x0806, IPv4 0x0800). When
+    // additional services come online they should register filtered
+    // listeners on the same Netif so they don't widen this surface.
+    uint16_t ethertype() const noexcept override { return kernel::net::ETHERTYPE_ANY; }
+    void on_eth_frame(int if_idx,
+                      kernel::hal::net::NetworkDriverOps& nic,
+                      const uint8_t* data, size_t len) noexcept override {
+        (void)if_idx;
+        handle_eth_frame(nic, data, len);
+    }
     enum class PingResult : uint8_t {
         Ok = 0,
         Busy,
@@ -79,12 +91,6 @@ public:
     static void thread_entry(void* arg);
 
 private:
-    struct Context {
-        Service* self;
-        kernel::hal::net::NetworkDriverOps* nic;
-    };
-
-    static void rx_trampoline(int if_idx, const uint8_t* data, size_t len, void* ctx) noexcept;
     void handle_eth_frame(kernel::hal::net::NetworkDriverOps& nic,
                           const uint8_t* data, size_t len) noexcept;
     void handle_raw_hmi(kernel::hal::net::NetworkDriverOps& nic,


### PR DESCRIPTION
## Summary
Tier-1 networking improvement #2 (of 3). Add `kernel::net::Netif` as the per-NIC RX dispatcher. Listeners register with an EtherType filter; multi-listener dispatch is now possible without editing the owning service. HMI is the only listener for now (catch-all), but the abstraction is what future services (and Tier 2's UDP socket layer) build on.

## Test plan
- [x] arm64 build clean
- [x] E2E (3-NIC layout): DHCP lease, gateway ARP learned, hostfwd UDP TSV upload landed — all via Netif now

https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_