### PR TITLE
net: UDP listener registry + udp_sendto helper

### DIFF
--- a/hal/shared/netif.cpp
+++ b/hal/shared/netif.cpp
@@ -2,7 +2,62 @@
 
 #include "netif.hpp"
 
+#include <cstring>
+
 namespace kernel::net {
+
+namespace {
+
+constexpr uint16_t ETHERTYPE_IPV4 = 0x0800u;
+constexpr uint8_t  IPPROTO_UDP    = 17u;
+
+// Packed L2/L3/L4 header structs — kept locally so the netif doesn't
+// depend on hmi/* layout. Identical wire format.
+struct EthernetHeader {
+    uint8_t  dst[6];
+    uint8_t  src[6];
+    uint16_t ethertype_be;
+} __attribute__((packed));
+
+struct IPv4Header {
+    uint8_t  ver_ihl;
+    uint8_t  dscp_ecn;
+    uint16_t total_len_be;
+    uint16_t ident_be;
+    uint16_t flags_frag_be;
+    uint8_t  ttl;
+    uint8_t  proto;
+    uint16_t hdr_checksum_be;
+    uint32_t src_ip_be;
+    uint32_t dst_ip_be;
+} __attribute__((packed));
+
+struct UdpHeader {
+    uint16_t src_port_be;
+    uint16_t dst_port_be;
+    uint16_t length_be;
+    uint16_t checksum_be;
+} __attribute__((packed));
+
+inline uint16_t bswap16(uint16_t v) { return static_cast<uint16_t>((v >> 8) | (v << 8)); }
+inline uint32_t bswap32(uint32_t v) {
+    return ((v & 0x000000FFu) << 24) |
+           ((v & 0x0000FF00u) <<  8) |
+           ((v & 0x00FF0000u) >>  8) |
+           ((v & 0xFF000000u) >> 24);
+}
+
+uint16_t ip_checksum(const uint8_t* data, size_t len) noexcept {
+    uint32_t sum = 0;
+    for (size_t i = 0; i + 1 < len; i += 2) {
+        sum += static_cast<uint16_t>((static_cast<uint16_t>(data[i]) << 8) | data[i + 1]);
+    }
+    if (len & 1u) sum += static_cast<uint16_t>(data[len - 1] << 8);
+    while (sum >> 16) sum = (sum & 0xFFFFu) + (sum >> 16);
+    return static_cast<uint16_t>(~sum);
+}
+
+} // namespace
 
 Netif g_netifs[MAX_NETIFS];
 
@@ -37,8 +92,78 @@ void Netif::rx_trampoline(int if_idx, const uint8_t* data, size_t len, void* ctx
     if (self) self->dispatch(if_idx, data, len);
 }
 
+bool Netif::register_udp_listener(UdpListener* l) noexcept {
+    if (!l || udp_listener_count_ >= MAX_UDP_LISTENERS) return false;
+    for (size_t i = 0; i < udp_listener_count_; ++i) {
+        if (udp_listeners_[i] == l) return true;
+    }
+    udp_listeners_[udp_listener_count_++] = l;
+    return true;
+}
+
+void Netif::unregister_udp_listener(UdpListener* l) noexcept {
+    for (size_t i = 0; i < udp_listener_count_; ++i) {
+        if (udp_listeners_[i] == l) {
+            for (size_t j = i + 1; j < udp_listener_count_; ++j) {
+                udp_listeners_[j - 1] = udp_listeners_[j];
+            }
+            udp_listeners_[--udp_listener_count_] = nullptr;
+            return;
+        }
+    }
+}
+
+bool Netif::udp_port_claimed(uint16_t local_port) const noexcept {
+    for (size_t i = 0; i < udp_listener_count_; ++i) {
+        auto* l = udp_listeners_[i];
+        if (!l) continue;
+        const uint16_t p = l->local_port();
+        if (p == 0 || p == local_port) return true;
+    }
+    return false;
+}
+
+void Netif::try_dispatch_udp(int if_idx, const uint8_t* data, size_t len) noexcept {
+    if (!nic_) return;
+    if (len < sizeof(EthernetHeader) + sizeof(IPv4Header) + sizeof(UdpHeader)) return;
+    const auto* eth = reinterpret_cast<const EthernetHeader*>(data);
+    if (bswap16(eth->ethertype_be) != ETHERTYPE_IPV4) return;
+    const auto* ip = reinterpret_cast<const IPv4Header*>(data + sizeof(EthernetHeader));
+    const uint8_t ihl = (ip->ver_ihl & 0x0Fu) * 4u;
+    if ((ip->ver_ihl >> 4) != 4 || ihl < sizeof(IPv4Header)) return;
+    if (ip->proto != IPPROTO_UDP) return;
+    const size_t ip_total = bswap16(ip->total_len_be);
+    if (sizeof(EthernetHeader) + ip_total > len) return;
+    if (ip_total < ihl + sizeof(UdpHeader)) return;
+    const auto* udp = reinterpret_cast<const UdpHeader*>(
+        data + sizeof(EthernetHeader) + ihl);
+    const uint16_t udp_len = bswap16(udp->length_be);
+    if (udp_len < sizeof(UdpHeader)) return;
+    if (sizeof(EthernetHeader) + ihl + udp_len > len) return;
+    const uint16_t dst_port = bswap16(udp->dst_port_be);
+    const uint16_t src_port = bswap16(udp->src_port_be);
+    const uint32_t src_ip = bswap32(ip->src_ip_be);
+    const uint32_t dst_ip = bswap32(ip->dst_ip_be);
+    const uint8_t* payload = reinterpret_cast<const uint8_t*>(udp) + sizeof(UdpHeader);
+    const size_t payload_len = udp_len - sizeof(UdpHeader);
+    for (size_t i = 0; i < udp_listener_count_; ++i) {
+        auto* l = udp_listeners_[i];
+        if (!l) continue;
+        const uint16_t want = l->local_port();
+        if (want != 0 && want != dst_port) continue;
+        l->on_udp(if_idx, *nic_, eth->src,
+                  src_ip, src_port, dst_ip, dst_port,
+                  payload, payload_len);
+    }
+}
+
 void Netif::dispatch(int if_idx, const uint8_t* data, size_t len) noexcept {
     if (!data || len < 14) return;
+    // UDP listeners are tried first. Eth-frame listeners come after so
+    // existing catch-all consumers (HMI's handle_eth_frame) still see
+    // every frame; HMI gates its handle_udp on udp_port_claimed() to
+    // avoid double-dispatch on ports owned by a UDP listener.
+    try_dispatch_udp(if_idx, data, len);
     const uint16_t et_be = static_cast<uint16_t>((data[12] << 8) | data[13]);
     for (size_t i = 0; i < listener_count_; ++i) {
         auto* l = listeners_[i];
@@ -64,6 +189,53 @@ Netif* netif_get(int if_idx) noexcept {
     if (if_idx < 0 || static_cast<size_t>(if_idx) >= MAX_NETIFS) return nullptr;
     Netif* n = &g_netifs[if_idx];
     return (n->nic() != nullptr) ? n : nullptr;
+}
+
+bool udp_sendto(Netif& netif,
+                const uint8_t* dst_mac, const uint8_t* src_mac,
+                uint32_t src_ip, uint32_t dst_ip,
+                uint16_t src_port, uint16_t dst_port,
+                const uint8_t* payload, size_t payload_len) noexcept {
+    constexpr size_t FRAME_CAP = 2048;
+    constexpr size_t HDRS = sizeof(EthernetHeader) + sizeof(IPv4Header) + sizeof(UdpHeader);
+    if (!dst_mac || !src_mac) return false;
+    if (payload_len > FRAME_CAP - HDRS) return false;
+    auto* nic = netif.nic();
+    if (!nic) return false;
+
+    static uint8_t frame[FRAME_CAP];  // single-threaded per netif (one worker per NIC)
+    std::memset(frame, 0, HDRS);
+
+    auto* eth = reinterpret_cast<EthernetHeader*>(frame);
+    for (size_t i = 0; i < 6; ++i) {
+        eth->dst[i] = dst_mac[i];
+        eth->src[i] = src_mac[i];
+    }
+    eth->ethertype_be = bswap16(ETHERTYPE_IPV4);
+
+    auto* ip = reinterpret_cast<IPv4Header*>(frame + sizeof(EthernetHeader));
+    ip->ver_ihl       = 0x45;
+    ip->dscp_ecn      = 0;
+    ip->total_len_be  = bswap16(static_cast<uint16_t>(sizeof(IPv4Header) + sizeof(UdpHeader) + payload_len));
+    ip->ident_be      = 0;
+    ip->flags_frag_be = 0;
+    ip->ttl           = 64;
+    ip->proto         = IPPROTO_UDP;
+    ip->hdr_checksum_be = 0;
+    ip->src_ip_be     = bswap32(src_ip);
+    ip->dst_ip_be     = bswap32(dst_ip);
+    ip->hdr_checksum_be = bswap16(ip_checksum(reinterpret_cast<const uint8_t*>(ip), sizeof(IPv4Header)));
+
+    auto* udp = reinterpret_cast<UdpHeader*>(frame + sizeof(EthernetHeader) + sizeof(IPv4Header));
+    udp->src_port_be = bswap16(src_port);
+    udp->dst_port_be = bswap16(dst_port);
+    udp->length_be   = bswap16(static_cast<uint16_t>(sizeof(UdpHeader) + payload_len));
+    udp->checksum_be = 0;  // IPv4 permits zero — Tier 2 follow-up
+
+    if (payload_len && payload) {
+        std::memcpy(frame + HDRS, payload, payload_len);
+    }
+    return nic->send_packet(netif.if_idx(), frame, HDRS + payload_len);
 }
 
 } // namespace kernel::net

--- a/hal/shared/netif.hpp
+++ b/hal/shared/netif.hpp
@@ -40,24 +40,69 @@ public:
                               const uint8_t* data, size_t len) noexcept = 0;
 };
 
+// UDP listener — one per (netif, local_port). Registered listeners
+// receive parsed IPv4+UDP datagrams; the Netif strips the L2/L3/L4
+// headers and hands the payload back. Eth/IP/UDP header validation
+// (header length, checksum, length sanity) is the Netif's job.
+class UdpListener {
+public:
+    virtual ~UdpListener() = default;
+    // Bound UDP local port (host order). 0 = listen on all ports
+    // (catch-all; useful for diagnostics, otherwise leave to a real port).
+    virtual uint16_t local_port() const noexcept = 0;
+    virtual void on_udp(int if_idx,
+                        kernel::hal::net::NetworkDriverOps& nic,
+                        const uint8_t* eth_src,
+                        uint32_t src_ip, uint16_t src_port,
+                        uint32_t dst_ip, uint16_t dst_port,
+                        const uint8_t* payload, size_t payload_len) noexcept = 0;
+};
+
+class Netif;
+
+// Build and send a UDP/IPv4/Ethernet datagram via `netif`. Caller
+// supplies the already-resolved L2 dst MAC and our src MAC + src IP
+// (L3 state still lives in the owning service for now). Returns
+// false if the payload is too large for the staging buffer.
+//
+// Max payload is bounded by the staging buffer below; we currently
+// reserve 2 KB total which allows ~1958 bytes of UDP payload past
+// Eth/IP/UDP overhead. Bigger payloads need IP fragmentation, which
+// the kernel doesn't do yet.
+bool udp_sendto(Netif& netif,
+                const uint8_t* dst_mac, const uint8_t* src_mac,
+                uint32_t src_ip, uint32_t dst_ip,
+                uint16_t src_port, uint16_t dst_port,
+                const uint8_t* payload, size_t payload_len) noexcept;
+
 class Netif {
 public:
     static constexpr size_t MAX_LISTENERS = 4;
+    static constexpr size_t MAX_UDP_LISTENERS = 8;
     void bind(int if_idx, kernel::hal::net::NetworkDriverOps* nic) noexcept;
     bool register_listener(EthListener* l) noexcept;
     void unregister_listener(EthListener* l) noexcept;
+    bool register_udp_listener(UdpListener* l) noexcept;
+    void unregister_udp_listener(UdpListener* l) noexcept;
     // Drain up to `budget` frames from the NIC's RX queue, dispatching
     // each to matching listeners. Returns frame count.
     size_t poll(size_t budget) noexcept;
     int if_idx() const noexcept { return if_idx_; }
     kernel::hal::net::NetworkDriverOps* nic() const noexcept { return nic_; }
+    // True if any UdpListener owns this local port — used by the legacy
+    // L2-catch-all path in HMI to skip frames that are about to be
+    // dispatched (or already were) via the UDP listener route.
+    bool udp_port_claimed(uint16_t local_port) const noexcept;
 private:
     static void rx_trampoline(int if_idx, const uint8_t* data, size_t len, void* ctx) noexcept;
     void dispatch(int if_idx, const uint8_t* data, size_t len) noexcept;
+    void try_dispatch_udp(int if_idx, const uint8_t* data, size_t len) noexcept;
     int if_idx_ = -1;
     kernel::hal::net::NetworkDriverOps* nic_ = nullptr;
     EthListener* listeners_[MAX_LISTENERS]{};
     size_t listener_count_ = 0;
+    UdpListener* udp_listeners_[MAX_UDP_LISTENERS]{};
+    size_t udp_listener_count_ = 0;
 };
 
 constexpr size_t MAX_NETIFS = 4;

--- a/hmi/hmi_service.cpp
+++ b/hmi/hmi_service.cpp
@@ -27,7 +27,9 @@ constexpr uint8_t IPPROTO_ICMP = 1;
 // B5: live preview — TSV-upload UDP listener. Editor / host bridge sends
 // chunked TSV via UDP to this port; kernel reassembles into a static
 // buffer and calls ui_builder::load_tsv on the last chunk.
-constexpr uint16_t UDP_PORT_TSV_UPLOAD = 5002;
+// UDP_PORT_TSV_UPLOAD is the public Service::UDP_PORT_TSV_UPLOAD; aliased
+// here so the file's existing references compile unchanged.
+constexpr uint16_t UDP_PORT_TSV_UPLOAD = Service::UDP_PORT_TSV_UPLOAD;
 // 16-byte chunk header (all little-endian to match the rest of the HMI
 // protocol). Layout:
 //   bytes 0-3  : magic 'T','S','V','U'
@@ -502,19 +504,13 @@ void Service::send_udp_packet(kernel::hal::net::NetworkDriverOps& nic,
                               uint16_t src_port, uint16_t dst_port,
                               const uint8_t* payload, size_t payload_len,
                               uint8_t protocol) noexcept {
-    uint8_t packet[512]{};
-    const size_t total = sizeof(UdpHeader) + payload_len;
-    if (total > sizeof(packet) || protocol != IPPROTO_UDP) return;
-    auto* udp = reinterpret_cast<UdpHeader*>(packet);
-    udp->src_port_be = host_to_be16(src_port);
-    udp->dst_port_be = host_to_be16(dst_port);
-    udp->length_be = host_to_be16(static_cast<uint16_t>(sizeof(UdpHeader) + payload_len));
-    udp->checksum_be = 0; // IPv4 permits zero UDP checksum
-
-    if (payload_len && payload) {
-        kernel::util::kmemcpy(packet + sizeof(UdpHeader), payload, payload_len);
-    }
-    send_ipv4_packet(nic, dst_mac, src_ip, dst_ip, packet, total, protocol);
+    (void)nic;
+    if (protocol != IPPROTO_UDP) return;
+    auto* netif = kernel::net::netif_get(nic_idx_);
+    if (!netif) return;
+    (void)kernel::net::udp_sendto(*netif, dst_mac, mac_,
+                                  src_ip, dst_ip, src_port, dst_port,
+                                  payload, payload_len);
 }
 
 void Service::send_arp_request(kernel::hal::net::NetworkDriverOps& nic,
@@ -1191,12 +1187,14 @@ void Service::handle_udp(kernel::hal::net::NetworkDriverOps& nic,
                          uint32_t src_ip, uint16_t src_port,
                          uint32_t, uint16_t dst_port,
                          const uint8_t* payload, size_t payload_len) noexcept {
-    if (dst_port == UDP_PORT_DHCP_CLIENT) {
-        handle_dhcp(nic, src_ip, payload, payload_len);
+    // Skip ports owned by a registered UdpListener — those are
+    // dispatched ahead of the eth-catch-all path inside Netif so we'd
+    // double-deliver if we processed them here too.
+    if (auto* nif = kernel::net::netif_get(nic_idx_); nif && nif->udp_port_claimed(dst_port)) {
         return;
     }
-    if (dst_port == UDP_PORT_TSV_UPLOAD) {
-        handle_tsv_upload(payload, payload_len);
+    if (dst_port == UDP_PORT_DHCP_CLIENT) {
+        handle_dhcp(nic, src_ip, payload, payload_len);
         return;
     }
     if (dst_port != udp_port_ || !configured()) return;
@@ -1398,6 +1396,7 @@ void Service::thread_entry(void* arg) {
         return;
     }
     netif->register_listener(self);
+    netif->register_udp_listener(self);
     for (;;) {
         self->maybe_drive_dhcp(*nic);
         (void)netif->poll(8);

--- a/hmi/hmi_service.hpp
+++ b/hmi/hmi_service.hpp
@@ -24,9 +24,10 @@ struct Config {
     uint32_t ping_selftest_timeout_ms = 3000;
 };
 
-class Service : public kernel::net::EthListener {
+class Service : public kernel::net::EthListener, public kernel::net::UdpListener {
 public:
     static constexpr uint16_t ETHERTYPE = 0x88B5;
+    static constexpr uint16_t UDP_PORT_TSV_UPLOAD = 5002;
     // EthListener: catch-all so we keep receiving every frame type the
     // HMI service handles (raw 0x88B5, ARP 0x0806, IPv4 0x0800). When
     // additional services come online they should register filtered
@@ -37,6 +38,21 @@ public:
                       const uint8_t* data, size_t len) noexcept override {
         (void)if_idx;
         handle_eth_frame(nic, data, len);
+    }
+    // UdpListener for the TSV-upload port. Frames used to travel via
+    // eth-catch-all → handle_ipv4 → handle_udp → handle_tsv_upload;
+    // now they come in directly. handle_udp skips this port via
+    // Netif::udp_port_claimed so the dispatch happens once.
+    uint16_t local_port() const noexcept override { return UDP_PORT_TSV_UPLOAD; }
+    void on_udp(int if_idx,
+                kernel::hal::net::NetworkDriverOps& nic,
+                const uint8_t* eth_src,
+                uint32_t src_ip, uint16_t src_port,
+                uint32_t dst_ip, uint16_t dst_port,
+                const uint8_t* payload, size_t payload_len) noexcept override {
+        (void)if_idx; (void)nic; (void)eth_src;
+        (void)src_ip; (void)src_port; (void)dst_ip; (void)dst_port;
+        handle_tsv_upload(payload, payload_len);
     }
     enum class PingResult : uint8_t {
         Ok = 0,


### PR DESCRIPTION
## Summary
Tier-2 step #1. Adds the UDP socket layer: `UdpListener` interface, `register_udp_listener`, dispatched ahead of eth-frame catch-all. TX side gets `kernel::net::udp_sendto`, a 50-LOC helper that builds Eth+IP+UDP once and sends — HMI's `send_udp_packet` is now a thin wrapper.

The legacy hand-rolled UDP TX used a 512-byte frame buffer; `udp_sendto`'s staging buffer is 2 KB, lifting the practical UDP payload cap from ~480 B to ~1958 B. Bigger payloads need IP fragmentation (Tier 2 follow-up).

`Service` now multi-inherits `EthListener` + `UdpListener`. As a `UdpListener` it claims port 5002 (TSV upload); the legacy `handle_udp` skips claimed ports so each frame is delivered exactly once.

## Test plan
- [x] arm64 build clean
- [x] E2E: TSV upload now flows through Service::on_udp via the netif dispatcher (not handle_eth_frame → handle_ipv4 → handle_udp anymore)
- [x] DHCP path (legacy) still works — no UdpListener registered for port 68 yet

https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_