### PR TITLE
net: IP fragmentation + UDP checksum on udp_sendto

### DIFF
--- a/hal/shared/netif.cpp
+++ b/hal/shared/netif.cpp
@@ -132,6 +132,13 @@ void Netif::try_dispatch_udp(int if_idx, const uint8_t* data, size_t len) noexce
     const uint8_t ihl = (ip->ver_ihl & 0x0Fu) * 4u;
     if ((ip->ver_ihl >> 4) != 4 || ihl < sizeof(IPv4Header)) return;
     if (ip->proto != IPPROTO_UDP) return;
+    // Drop IPv4 fragments — RX reassembly isn't implemented yet. The
+    // MF flag (bit 13) or a non-zero fragment offset (bits 0–12) means
+    // this is mid-datagram. Hosts behind QEMU's SLIRP / hostfwd never
+    // see fragments because Linux / SLIRP reassemble for us, so this
+    // matters only on real hardware with a misconfigured peer.
+    const uint16_t flags_frag = bswap16(ip->flags_frag_be);
+    if ((flags_frag & 0x2000u) || (flags_frag & 0x1FFFu)) return;
     const size_t ip_total = bswap16(ip->total_len_be);
     if (sizeof(EthernetHeader) + ip_total > len) return;
     if (ip_total < ihl + sizeof(UdpHeader)) return;
@@ -191,51 +198,114 @@ Netif* netif_get(int if_idx) noexcept {
     return (n->nic() != nullptr) ? n : nullptr;
 }
 
+namespace {
+
+// IPv4 fragmentation flag bits (in flags_frag_be field, host order).
+constexpr uint16_t IP_FLAG_MF = 0x2000;     // more fragments
+constexpr uint16_t IP_FRAG_OFFSET_MASK = 0x1FFF;
+constexpr size_t   IP_MTU = 1500;
+constexpr size_t   MAX_FRAG_PAYLOAD = (IP_MTU - sizeof(IPv4Header)) & ~size_t{7};  // 1480
+// Hard cap on the UDP segment we'll fragment. Most consumers send well
+// under this (TSV upload chunks at 1400 bytes); the cap exists so the
+// staging buffer doesn't grow unbounded.
+constexpr size_t MAX_UDP_PAYLOAD = 8192;
+constexpr size_t FRAME_CAP = 2048;  // one MTU + slack
+
+// IP datagram identification — incremented per outbound datagram so
+// re-fragmentation by a downstream router (if any) won't alias with
+// the next datagram from this host.
+uint16_t g_ip_ident = 0x4d49;  // 'MI'
+
+uint16_t udp_checksum(uint32_t src_ip, uint32_t dst_ip,
+                      const uint8_t* udp_segment, size_t udp_len) noexcept {
+    // Pseudo-header: src(4) dst(4) zero(1) proto(1) udp_len(2) = 12 bytes.
+    uint32_t sum = 0;
+    sum += (src_ip >> 16) & 0xFFFFu;
+    sum +=  src_ip        & 0xFFFFu;
+    sum += (dst_ip >> 16) & 0xFFFFu;
+    sum +=  dst_ip        & 0xFFFFu;
+    sum += IPPROTO_UDP;
+    sum += static_cast<uint16_t>(udp_len);
+    for (size_t i = 0; i + 1 < udp_len; i += 2) {
+        sum += static_cast<uint16_t>((static_cast<uint16_t>(udp_segment[i]) << 8) | udp_segment[i + 1]);
+    }
+    if (udp_len & 1u) sum += static_cast<uint16_t>(udp_segment[udp_len - 1] << 8);
+    while (sum >> 16) sum = (sum & 0xFFFFu) + (sum >> 16);
+    uint16_t cs = static_cast<uint16_t>(~sum);
+    // RFC 768: a transmitted zero checksum is reserved to mean "no
+    // checksum used"; if the real checksum computes to 0, transmit
+    // 0xFFFF instead.
+    return cs == 0 ? 0xFFFFu : cs;
+}
+
+} // namespace
+
 bool udp_sendto(Netif& netif,
                 const uint8_t* dst_mac, const uint8_t* src_mac,
                 uint32_t src_ip, uint32_t dst_ip,
                 uint16_t src_port, uint16_t dst_port,
                 const uint8_t* payload, size_t payload_len) noexcept {
-    constexpr size_t FRAME_CAP = 2048;
-    constexpr size_t HDRS = sizeof(EthernetHeader) + sizeof(IPv4Header) + sizeof(UdpHeader);
     if (!dst_mac || !src_mac) return false;
-    if (payload_len > FRAME_CAP - HDRS) return false;
+    if (payload_len > MAX_UDP_PAYLOAD) return false;
     auto* nic = netif.nic();
     if (!nic) return false;
 
-    static uint8_t frame[FRAME_CAP];  // single-threaded per netif (one worker per NIC)
-    std::memset(frame, 0, HDRS);
+    // Single-threaded per netif (one worker thread owns each NIC).
+    static uint8_t udp_segment[MAX_UDP_PAYLOAD + sizeof(UdpHeader)];
+    static uint8_t frame[FRAME_CAP];
 
-    auto* eth = reinterpret_cast<EthernetHeader*>(frame);
-    for (size_t i = 0; i < 6; ++i) {
-        eth->dst[i] = dst_mac[i];
-        eth->src[i] = src_mac[i];
-    }
-    eth->ethertype_be = bswap16(ETHERTYPE_IPV4);
-
-    auto* ip = reinterpret_cast<IPv4Header*>(frame + sizeof(EthernetHeader));
-    ip->ver_ihl       = 0x45;
-    ip->dscp_ecn      = 0;
-    ip->total_len_be  = bswap16(static_cast<uint16_t>(sizeof(IPv4Header) + sizeof(UdpHeader) + payload_len));
-    ip->ident_be      = 0;
-    ip->flags_frag_be = 0;
-    ip->ttl           = 64;
-    ip->proto         = IPPROTO_UDP;
-    ip->hdr_checksum_be = 0;
-    ip->src_ip_be     = bswap32(src_ip);
-    ip->dst_ip_be     = bswap32(dst_ip);
-    ip->hdr_checksum_be = bswap16(ip_checksum(reinterpret_cast<const uint8_t*>(ip), sizeof(IPv4Header)));
-
-    auto* udp = reinterpret_cast<UdpHeader*>(frame + sizeof(EthernetHeader) + sizeof(IPv4Header));
+    // Build the UDP segment once: header + payload, with proper checksum.
+    const size_t udp_seg_len = sizeof(UdpHeader) + payload_len;
+    auto* udp = reinterpret_cast<UdpHeader*>(udp_segment);
     udp->src_port_be = bswap16(src_port);
     udp->dst_port_be = bswap16(dst_port);
-    udp->length_be   = bswap16(static_cast<uint16_t>(sizeof(UdpHeader) + payload_len));
-    udp->checksum_be = 0;  // IPv4 permits zero — Tier 2 follow-up
-
+    udp->length_be   = bswap16(static_cast<uint16_t>(udp_seg_len));
+    udp->checksum_be = 0;  // zero for checksum computation
     if (payload_len && payload) {
-        std::memcpy(frame + HDRS, payload, payload_len);
+        std::memcpy(udp_segment + sizeof(UdpHeader), payload, payload_len);
     }
-    return nic->send_packet(netif.if_idx(), frame, HDRS + payload_len);
+    udp->checksum_be = bswap16(udp_checksum(src_ip, dst_ip, udp_segment, udp_seg_len));
+
+    const uint16_t ident = g_ip_ident++;
+    size_t offset = 0;
+    while (offset < udp_seg_len) {
+        const size_t remaining = udp_seg_len - offset;
+        const size_t chunk = (remaining > MAX_FRAG_PAYLOAD) ? MAX_FRAG_PAYLOAD : remaining;
+        const bool more = (offset + chunk) < udp_seg_len;
+        const size_t frame_len = sizeof(EthernetHeader) + sizeof(IPv4Header) + chunk;
+        if (frame_len > FRAME_CAP) return false;
+
+        std::memset(frame, 0, sizeof(EthernetHeader) + sizeof(IPv4Header));
+        auto* eth = reinterpret_cast<EthernetHeader*>(frame);
+        for (size_t i = 0; i < 6; ++i) {
+            eth->dst[i] = dst_mac[i];
+            eth->src[i] = src_mac[i];
+        }
+        eth->ethertype_be = bswap16(ETHERTYPE_IPV4);
+
+        auto* ip = reinterpret_cast<IPv4Header*>(frame + sizeof(EthernetHeader));
+        ip->ver_ihl       = 0x45;
+        ip->dscp_ecn      = 0;
+        ip->total_len_be  = bswap16(static_cast<uint16_t>(sizeof(IPv4Header) + chunk));
+        ip->ident_be      = bswap16(ident);
+        const uint16_t flags_frag = static_cast<uint16_t>(
+            (more ? IP_FLAG_MF : 0u) | ((offset / 8u) & IP_FRAG_OFFSET_MASK));
+        ip->flags_frag_be = bswap16(flags_frag);
+        ip->ttl           = 64;
+        ip->proto         = IPPROTO_UDP;
+        ip->hdr_checksum_be = 0;
+        ip->src_ip_be     = bswap32(src_ip);
+        ip->dst_ip_be     = bswap32(dst_ip);
+        ip->hdr_checksum_be = bswap16(ip_checksum(reinterpret_cast<const uint8_t*>(ip),
+                                                  sizeof(IPv4Header)));
+
+        std::memcpy(frame + sizeof(EthernetHeader) + sizeof(IPv4Header),
+                    udp_segment + offset, chunk);
+
+        if (!nic->send_packet(netif.if_idx(), frame, frame_len)) return false;
+        offset += chunk;
+    }
+    return true;
 }
 
 } // namespace kernel::net


### PR DESCRIPTION
## Summary
Tier-2 step #2 (TX) + #4 (UDP checksum). `udp_sendto` now fragments outbound UDP datagrams > MTU (1480 B IPv4 payload per fragment, 8-byte aligned) and emits proper RFC 768 UDP checksums (pseudo-header + UDP + payload; transmits 0xFFFF when the computed value is 0).

RX side rejects fragmented IPv4 packets cleanly (MF flag or non-zero offset). RX reassembly is future work — hosts behind QEMU SLIRP / Linux hostfwd reassemble for us, so this matters only on real hardware.

## Test plan
- [x] arm64 build clean
- [x] E2E (98-byte TSV) — single-fragment fast path
- [x] DHCP/ARP TX now carries real UDP checksums (SLIRP would silently drop malformed checksums, so passing E2E confirms the math)

https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_