### PR TITLE
net: IRQ-driven RX wakeup (arm64 + rv64)

### DIFF
--- a/hal.hpp
+++ b/hal.hpp
@@ -249,6 +249,11 @@ namespace net {
             (void)out;
             return false;
         }
+        // Called from device-IRQ context (Platform::handle_device_irq). The
+        // driver reads + ACKs the device-level interrupt status so the IRQ
+        // line de-asserts; nothing else here may block. Default no-op for
+        // drivers that don't model an MMIO interrupt status register.
+        virtual void acknowledge_irq() noexcept {}
         // Drain up to `budget` frames from the NIC RX queue, invoking `cb` for
         // each. Default no-op for ops that don't implement poll-mode RX.
         virtual size_t poll_rx(PacketReceivedCallback cb, void* context,

--- a/hal/arm64/hal_qemu_arm64.cpp
+++ b/hal/arm64/hal_qemu_arm64.cpp
@@ -10,6 +10,7 @@
 #include "klog.hpp"
 #include "rt_wait.hpp"
 #include "hal/shared/fdt_scan.hpp"
+#include "hal/shared/netif.hpp"
 #include <cstring>
 #include <algorithm>
 #include <new>
@@ -799,6 +800,22 @@ void PlatformQEMUVirtARM64::route_net_irq(int if_idx, uint32_t core_mask) {
     const uint32_t spi = virtio_nic_spi_ids_[if_idx];
     if (spi == 0 || core_mask == 0) return;
     irq_controller_.set_irq_affinity(spi, core_mask);
+}
+
+void PlatformQEMUVirtARM64::handle_device_irq(uint32_t core_id, uint32_t irq_id) {
+    (void)core_id;
+    // Map virtio NIC SPIs back to nic_idx. Match → ACK at the device level
+    // (drops the IRQ line so the GIC stops re-firing) and pulse the
+    // netif's rx-pending flag so the owning worker drains immediately.
+    for (size_t i = 0; i < sizeof(virtio_nic_spi_ids_) / sizeof(virtio_nic_spi_ids_[0]); ++i) {
+        if (virtio_nic_spi_ids_[i] == irq_id && virtio_nic_spi_ids_[i] != 0) {
+            virtio_nics_[i].acknowledge_irq();
+            if (auto* netif = kernel::net::netif_get(static_cast<int>(i))) {
+                netif->on_rx_irq();
+            }
+            return;
+        }
+    }
 }
 
 void PlatformQEMUVirtARM64::early_init_core(uint32_t core_id) {

--- a/hal/arm64/hal_qemu_arm64.hpp
+++ b/hal/arm64/hal_qemu_arm64.hpp
@@ -267,6 +267,7 @@ public:
     void early_init_platform() override;
     void early_init_core(uint32_t core_id) override;
     void route_net_irq(int if_idx, uint32_t core_mask) override;
+    void handle_device_irq(uint32_t core_id, uint32_t irq_id) override;
     [[noreturn]] void panic(const char* msg, const char* file, int line) override;
     void reboot_system() override;
     kernel::hal::UARTDriverOps* get_uart_ops() override { return &uart_driver_; }

--- a/hal/riscv64/hal_qemu_rv64.cpp
+++ b/hal/riscv64/hal_qemu_rv64.cpp
@@ -31,6 +31,7 @@
 #include "rt_wait.hpp"
 #include "fdt.hpp"
 #include "hal/shared/fdt_scan.hpp"
+#include "hal/shared/netif.hpp"
 #include "../../cli.hpp"
 #include "../../devices/device_db.hpp"
 #include "../../devices/embedded.hpp"
@@ -699,6 +700,23 @@ void PlatformQEMUVirtRV64::route_net_irq(int if_idx, uint32_t core_mask) {
     uart_.puts(" hart_mask=");
     uart_.uart_put_uint64_hex(static_cast<uint64_t>(core_mask));
     uart_.puts("\n");
+}
+
+void PlatformQEMUVirtRV64::handle_device_irq(uint32_t core_id, uint32_t irq_id) {
+    (void)core_id;
+    // Map virtio NIC PLIC IRQs back to nic_idx. Same shape as arm64 —
+    // ACK at the device level (drops the IRQ line so the PLIC stops
+    // re-firing) and pulse the netif's rx-pending flag so the owning
+    // worker drains immediately.
+    for (size_t i = 0; i < sizeof(virtio_nic_irq_ids_) / sizeof(virtio_nic_irq_ids_[0]); ++i) {
+        if (virtio_nic_irq_ids_[i] == irq_id && virtio_nic_irq_ids_[i] != 0) {
+            virtio_nics_[i].acknowledge_irq();
+            if (auto* netif = kernel::net::netif_get(static_cast<int>(i))) {
+                netif->on_rx_irq();
+            }
+            return;
+        }
+    }
 }
 
 [[noreturn]] void PlatformQEMUVirtRV64::panic(const char* msg, const char* file, int line) {

--- a/hal/riscv64/hal_qemu_rv64.hpp
+++ b/hal/riscv64/hal_qemu_rv64.hpp
@@ -210,6 +210,7 @@ public:
     // once after PLIC init.
     void discover_virtio_nets();
     void route_net_irq(int if_idx, uint32_t core_mask) override;
+    void handle_device_irq(uint32_t core_id, uint32_t irq_id) override;
     kernel::hal::PowerOps*                get_power_ops() override { return &power_ops_; }
     kernel::hal::gpio::GPIODriverOps*     get_gpio_ops() override { return nullptr; }
     kernel::hal::WatchdogOps*             get_watchdog_ops() override { return nullptr; }

--- a/hal/shared/netif.hpp
+++ b/hal/shared/netif.hpp
@@ -15,6 +15,7 @@
 
 #include "../../hal.hpp"
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 
@@ -93,6 +94,17 @@ public:
     // L2-catch-all path in HMI to skip frames that are about to be
     // dispatched (or already were) via the UDP listener route.
     bool udp_port_claimed(uint16_t local_port) const noexcept;
+
+    // Called from device-IRQ context (Platform::handle_device_irq) when
+    // the NIC's interrupt line asserts. Sets an atomic flag; the worker
+    // thread picks it up via consume_rx_pending() and drains aggressively
+    // until poll() returns 0. Safe to call from IRQ.
+    void on_rx_irq() noexcept { rx_irq_pending_.store(true, std::memory_order_release); }
+    // Returns true if on_rx_irq() was called since the last consume; also
+    // clears the flag in one shot.
+    bool consume_rx_pending() noexcept {
+        return rx_irq_pending_.exchange(false, std::memory_order_acq_rel);
+    }
 private:
     static void rx_trampoline(int if_idx, const uint8_t* data, size_t len, void* ctx) noexcept;
     void dispatch(int if_idx, const uint8_t* data, size_t len) noexcept;
@@ -103,6 +115,7 @@ private:
     size_t listener_count_ = 0;
     UdpListener* udp_listeners_[MAX_UDP_LISTENERS]{};
     size_t udp_listener_count_ = 0;
+    std::atomic<bool> rx_irq_pending_{false};
 };
 
 constexpr size_t MAX_NETIFS = 4;

--- a/hal/shared/virtio_net.cpp
+++ b/hal/shared/virtio_net.cpp
@@ -128,6 +128,17 @@ bool VirtioNetDriver::init_interface(int if_idx) {
     return initialized_;
 }
 
+void VirtioNetDriver::acknowledge_irq() noexcept {
+    // Called from IRQ context. virtio-mmio levels the IRQ line until we
+    // clear the matching bit in VMMIO_INT_STATUS via VMMIO_INT_ACK; if we
+    // don't, the GIC/PLIC keeps re-firing forever. The slow-path poll
+    // also does this, but doing it here is what lets the IRQ line
+    // de-assert promptly and avoids interrupt storms on busy NICs.
+    if (!initialized_) return;
+    const uint32_t status = mmio_read(VMMIO_INT_STATUS);
+    if (status != 0) mmio_write(VMMIO_INT_ACK, status);
+}
+
 bool VirtioNetDriver::send_packet(int if_idx, const uint8_t* data, size_t len) {
     (void)if_idx;
     if (!initialized_ || !data) { stats_.tx_drops++; return false; }

--- a/hal/shared/virtio_net.hpp
+++ b/hal/shared/virtio_net.hpp
@@ -113,6 +113,7 @@ public:
     bool init_interface(int if_idx) override;
     bool send_packet(int if_idx, const uint8_t* data, size_t len) override;
     void register_packet_receiver(kernel::hal::net::PacketReceivedCallback cb, void* context) override;
+    void acknowledge_irq() noexcept override;
     kernel::hal::net::NicStats get_stats() const override { return stats_; }
     bool get_mac(uint8_t out[6]) const override;
 

--- a/hmi/hmi_service.cpp
+++ b/hmi/hmi_service.cpp
@@ -1473,11 +1473,13 @@ void Service::thread_entry(void* arg) {
     bool burst = false;
     for (;;) {
         self->maybe_drive_dhcp(*nic);
+        // IRQ-driven hint: device IRQ flips netif->rx_irq_pending; we
+        // consume it here and drain harder if set. Otherwise rely on
+        // the poll's return — a full budget likely means more work,
+        // anything less drained the queue and we can yield.
+        const bool irq_pending = netif->consume_rx_pending();
         const size_t rx = netif->poll(POLL_BUDGET);
-        // A full-budget drain means there's likely more in the queue —
-        // skip the yield at end-of-loop and come straight back to poll.
-        // Empties yield as before so the worker doesn't pin a core.
-        burst = (rx >= POLL_BUDGET);
+        burst = irq_pending || (rx >= POLL_BUDGET);
         self->process_ping(*nic);
         if (self->config_.ping_selftest_enable &&
             !self->ping_selftest_started_ &&


### PR DESCRIPTION
## Summary
Closes the Tier-2 follow-up. Device IRQ → `Platform::handle_device_irq` now ACKs INT_STATUS at the virtio device and pulses the netif's `rx_irq_pending` flag; the worker consumes the flag and drains hard instead of waiting for the next poll.

Not a true blocking event primitive (the kernel doesn't have condvars), but the loop now reacts to incoming traffic on the IRQ rather than only on the next scheduler quantum.

## Test plan
- [x] arm64 build clean
- [x] rv64 build clean  
- [x] E2E (arm64): WS path unchanged through the new IRQ-ACK code

https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_