### PR TITLE
ui_editor: default Push-to-kernel to the kernel's WebSocket server

### DIFF
--- a/tools/ui_editor/index.html
+++ b/tools/ui_editor/index.html
@@ -146,7 +146,7 @@
     <button id="btnOpen">Open</button>
     <button id="btnSave">Save</button>
     <button id="btnSaveAs">Save As</button>
-    <button id="btnPushKernel" title="B5 live preview: push current TSV to a running kernel via the host bridge (tools/ui_editor/live_preview.py)">Push to kernel</button>
+    <button id="btnPushKernel" title="Live preview: push current TSV to a running kernel over WebSocket. Defaults to ws://localhost:5001/ which talks to the kernel's WebSocket server directly. Override via the 'livePreviewUrl' localStorage key (e.g. ws://10.0.0.20:5001/) when the kernel is on another host. The Python bridge in tools/ui_editor/live_preview.py is still supported as a fallback if direct WS isn't reachable.">Push to kernel</button>
     <input type="file" id="fileInput" accept=".tsv" style="display:none">
     <span class="sep"></span>
     <div id="pagetabs"></div>
@@ -1675,12 +1675,20 @@ $("#btnSave").addEventListener("click", () => saveFile());
 $("#btnSaveAs").addEventListener("click", () => saveAsFile());
 $("#btnPushKernel").addEventListener("click", () => pushToKernel());
 
-// B5: push the current TSV to a running kernel via the
-// live_preview.py host bridge. Bridge listens on
-// ws://localhost:5001/ by default; it chunks the TSV and forwards
-// to kernel:5002 via UDP. The kernel's hmi_service reassembles and
-// calls ui_builder::load_tsv. Edit-test loop drops from
-// rebuild-and-boot (~30 s) to "click + render" (~1 s).
+// Push the current TSV to a running kernel over WebSocket.
+//
+// Default: ws://localhost:5001/ talks to the kernel's WebSocket
+// server directly (PR #48). The kernel's hmi_service runs the WS
+// handshake, receives the TSV as a single text frame, and calls
+// ui_builder::load_tsv. Edit-test loop drops from rebuild-and-boot
+// (~30 s) to "click + render" (~1 s).
+//
+// When the kernel is on a different host, override via
+// localStorage.setItem("livePreviewUrl", "ws://<ip>:5001/").
+//
+// The Python bridge (tools/ui_editor/live_preview.py) is still
+// supported for setups that prefer chunked UDP rather than direct
+// TCP — point livePreviewUrl at the bridge instead.
 function pushToKernel() {
   const text = serializeTSV(doc);
   $("#status").textContent = (`pushing ${text.length} bytes ...`);
@@ -1689,7 +1697,7 @@ function pushToKernel() {
   try {
     ws = new WebSocket(url);
   } catch (e) {
-    $("#status").textContent = (`live-preview bridge not reachable at ${url}: ${e.message}`);
+    $("#status").textContent = (`live-preview unreachable at ${url}: ${e.message}`);
     return;
   }
   ws.onopen = () => {
@@ -1700,7 +1708,11 @@ function pushToKernel() {
     ws.close();
   };
   ws.onerror = () => {
-    $("#status").textContent = (`live-preview: bridge unreachable at ${url} — start with: python3 tools/ui_editor/live_preview.py --kernel-ip <ip>`);
+    $("#status").textContent = (
+      `live-preview: unreachable at ${url}. Default expects the kernel's WS server (port 5001). ` +
+      `For a remote kernel: localStorage.setItem('livePreviewUrl', 'ws://<ip>:5001/'). ` +
+      `For chunked-UDP via host bridge: python3 tools/ui_editor/live_preview.py --kernel-ip <ip>`
+    );
   };
   ws.onclose = () => {};
 }

--- a/tools/ui_editor/live_preview.py
+++ b/tools/ui_editor/live_preview.py
@@ -1,31 +1,30 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT OR Apache-2.0
 """
-B5 live-preview host bridge.
+Live-preview host bridge (legacy / fallback path).
 
-Sits between the browser-based UI editor (tools/ui_editor/index.html) and
-the kernel's UDP TSV-upload listener (hmi_service:5002). Editor connects
-via WebSocket, sends the current TSV as a single text frame; the bridge
-chunks it into UDP datagrams keyed by a session id and pushes them at
-the kernel. The kernel reassembles, calls ui_builder::load_tsv, repaints.
+The kernel now runs a WebSocket server itself (PR #48), so the editor
+connects to ws://<kernel>:5001/ directly in the default config. This
+bridge is no longer required for normal use.
 
-Why a bridge instead of WS direct from browser?
-  Browsers can't open raw UDP sockets, and the kernel only has UDP today
-  (no TCP, no HTTP, no WebSocket). The bridge bridges those gaps without
-  any new kernel network surface beyond the UDP listener that's already
-  in place.
+Keep it for two cases:
+  * The kernel is reachable only via a UDP path (e.g. a flat L2 segment
+    where TCP is filtered).
+  * You're debugging the chunked-UDP TSV upload protocol itself.
 
-Usage:
+How it worked:
+  Editor connects via WebSocket; bridge chunks the text frame into
+  1400-byte UDP datagrams keyed by a session id and pushes them at the
+  kernel's UDP listener on port 5002. The kernel reassembles + calls
+  ui_builder::load_tsv.
+
+Usage (only when you actually need the bridge):
   python3 tools/ui_editor/live_preview.py --kernel-ip 10.0.2.15
-  python3 tools/ui_editor/live_preview.py --kernel-ip 10.0.2.15 --port 5001
+  # then in the editor:
+  #   localStorage.setItem("livePreviewUrl", "ws://localhost:5001/")
+  # so the editor talks to this bridge rather than the kernel directly.
 
-  In the editor: click the new "Push to kernel" button. It connects to
-  ws://localhost:5001/ and streams the current TSV. The bridge prints
-  per-upload telemetry; the kernel logs `[hmi] tsv-upload session=...
-  complete ... load_tsv` on the serial console once the upload lands.
-
-Dependencies: stdlib only (websockets package not required — uses a
-minimal hand-rolled WS handshake that doesn't need pip install).
+Dependencies: stdlib only.
 """
 
 import argparse


### PR DESCRIPTION
## Summary
Docs/UX-only follow-up to PR #48. The default `ws://localhost:5001/` URL now talks to the kernel's WebSocket server directly, so the Python bridge is no longer required for normal use. Button tooltip + error messages updated, and the bridge's docstring is rewritten to describe it as a fallback (still useful for UDP-only environments).

No JS behaviour change.

https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwwfzbimgeMfjiKgS53qZ)_