### PR TITLE
rv64: force MPP=M in voluntary context-switch saved mstatus

### DIFF
--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -62,6 +62,16 @@ jobs:
         run: make TARGET=arm64
 
       - name: Capture every TSV UI page
+        # UI_DUMP_SCALE=3 downsamples the 1080×1920 framebuffer to 360×640.
+        # Native res (scale=1, the script default since 8d267ac) writes a
+        # 6.2 MB raw RGB payload per page over the emulated UART — ~31 s/page
+        # under QEMU TCG, so a full 20-page run overruns the runner and the
+        # job was timing out partway through the capture loop. Scale=3 keeps
+        # widget structure legible for the visual-review surface and brings
+        # the full run to ~2.6 min (measured 159 s). Raise toward 1 only if
+        # the runner budget allows.
+        env:
+          UI_DUMP_SCALE: "3"
         run: |
           mkdir -p screenshots
           # Strip stale captures so deleted pages don't linger as orphan PNGs.

--- a/hal/riscv64/cpu_rv64.S
+++ b/hal/riscv64/cpu_rv64.S
@@ -486,9 +486,24 @@ cpu_context_switch_rv64:
     sd      s11, (TCB_REGS_OFF + 26*8)(a0)
     /* Resume pc = ra (the call site of cpu_context_switch_rv64). */
     sd      ra,  (TCB_PC_OFF)(a0)
-    /* Save the pre-disable mstatus, but make sure MPIE=1 so when this
-     * thread is restored later via mret, MIE comes back on. */
-    ori     t1, t1, 0x80                /* set MPIE bit */
+    /* Save the pre-disable mstatus, fixing up the fields mret will consume:
+     *   MPIE (bit 7)      = 1  -> MIE comes back on when this thread resumes.
+     *   MPP  (bits 11-12) = M  -> mret stays in M-mode.
+     *
+     * MPP must be forced because RISC-V hardware *clears* mstatus.MPP to the
+     * least-privileged supported mode (User here) as a side-effect of the
+     * mret that first entered this thread. So while the thread runs in
+     * M-mode, the MPP *field* in the live mstatus reads U. If we saved that
+     * verbatim, the next mret restoring this TCB would drop to U-mode and the
+     * very next instruction fetch of kernel text would fault (mcause=1,
+     * tval=0) — observed at both mret sites (trap_entry and here). The trap
+     * save path doesn't need this fixup: a trap from M-mode sets MPP=M in
+     * hardware, so its captured mstatus already has MPP=M.
+     *
+     * MPP is only ever M (0b11) or U (0b00) in this kernel (no S-mode), so
+     * OR-ing in 0x1800 reliably forces it to M. */
+    li      t5, 0x1880                  /* MPIE | (MPP=M) */
+    or      t1, t1, t5
     sd      t1,  (TCB_MSTATUS_OFF)(a0)
 
 .L_ctx_restore:

--- a/scripts/rv64_boot_loop.sh
+++ b/scripts/rv64_boot_loop.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# rv64 boot reliability harness. Sequential (never races the build), captures
+# per-run pass/fail plus the first trap line for triage. Usage:
+#   scripts/rv64_boot_loop.sh [N]   (default 20)
+set -u
+ELF=build/riscv64/miniOS_kernel_riscv64.elf
+N=${1:-20}
+OUT=${RV64_LOOP_OUT:-/tmp/rv64_loop}
+mkdir -p "$OUT"
+reach=0; trap=0
+for i in $(seq 1 "$N"); do
+  log="$OUT/run_$i.log"
+  timeout 18 qemu-system-riscv64 -M virt -cpu max -smp 4 -m 128M -bios none \
+    -nographic -kernel "$ELF" > "$log" 2>&1
+  r=$(grep -c "miniOS CLI ready" "$log")
+  t=$(grep -c "rv64 TRAP" "$log")
+  [ "$r" -gt 0 ] && reach=$((reach+1))
+  [ "$t" -gt 0 ] && trap=$((trap+1))
+  first_trap=$(grep -m1 "rv64 TRAP" "$log" | sed 's/^.*\(mcause=[^ ]*\).*\(name=.*\)$/\1 \2/')
+  printf "run %2d: cli=%s trap=%s  %s\n" "$i" "$r" "$t" "$first_trap"
+done
+echo "SUMMARY: reached CLI $reach/$N, traps $trap/$N"


### PR DESCRIPTION
The documented rv64 boot fault (mcause=1 instruction-access, tval=0, on an
mret) is root-caused here. QEMU's hardware exception log (-d int) shows a
single synchronous fault per boot, always a fetch fault whose epc is an
mret instruction itself, at both mret sites (trap_entry and
cpu_context_switch_rv64).

Cause: RISC-V hardware clears mstatus.MPP to the least-privileged mode
(User here) as a side effect of the mret that first enters a thread. While
the thread then runs in M-mode, the MPP *field* in the live mstatus reads
U. cpu_context_switch_rv64's voluntary-save path read that live mstatus
and patched only MPIE, saving MPP=U into the TCB. On the next resume, mret
restored MPP=U, dropped to User mode, and the next instruction fetch of
kernel text faulted (no U-mode PMP execute permission). New threads
survived their first entry only because create_thread seeds MPP=M.

Fix: OR 0x1880 (MPIE | MPP=M) into the saved mstatus instead of 0x80
(MPIE only). The trap-save path needs no change: a trap from M-mode sets
MPP=M in hardware, so its captured mstatus already has MPP=M.

Verified with scripts/rv64_boot_loop.sh (new): traps 3/20 -> 0/20 over 20
sequential cold boots. NOTE: rv64 still does not reach the CLI banner -- a
separate, pre-existing scheduler deadlock (all harts spinning in
Spinlock::acquire_general, hanging at boot_ui_thread_entry) gates the
boot. Baseline main is also 0/20 to CLI in this environment. This commit
eliminates the memory-corruption/trap class only; the deadlock is the next
item.